### PR TITLE
malicious HTTP request kills gearmand

### DIFF
--- a/libgearman-server/plugins/protocol/http/protocol.cc
+++ b/libgearman-server/plugins/protocol/http/protocol.cc
@@ -294,7 +294,7 @@ public:
     {
       gearmand_log_error(GEARMAN_DEFAULT_LOG_PARAM, "bad request line: %.*s", (uint32_t)request_size, request);
       set_response(gearmand::protocol::httpd::HTTP_NOT_FOUND);
-      ret_ptr= GEARMAND_SUCCESS;
+      ret_ptr= GEARMAND_INVALID_PACKET;
       return 0;
     }
 
@@ -330,7 +330,7 @@ public:
       {
         gearmand_log_error(GEARMAN_DEFAULT_LOG_PARAM, "bad method: %.*s", (uint32_t)method_size, method_str);
         set_response(gearmand::protocol::httpd::HTTP_METHOD_NOT_ALLOWED);
-        ret_ptr= GEARMAND_SUCCESS;
+        ret_ptr= GEARMAND_INVALID_PACKET;
         return 0;
       }
     }


### PR DESCRIPTION
[LP](http://bazaar.launchpad.net/~1-infe-w/gearmand/1.0/revision/802)

debian Bug#774143: Acknowledgement 
> Package: gearman-job-server
Version: 1.0.6-4
Status: install ok installed
Installed-Size: 268
Architecture: amd64
Severity: serious

> A bad HTTP request force gearmand (>=0.33 AFAIK) to run in in endless loop until memory out. See bug report https://bugs.launchpad.net/gearmand/+bug/1348865
