### PR TITLE
Use git describe to determine version

### DIFF
--- a/version.m4
+++ b/version.m4
@@ -1,1 +1,1 @@
-m4_define([VERSION_NUMBER], [1.1.12])
+m4_define([VERSION_NUMBER], m4_esyscmd_s([git describe --always]))


### PR DESCRIPTION
This ties tags to commits that build them rather than requiring an extra
commit to make a release.