### PR TITLE
Add "redis-password" option of to connect redis server

### DIFF
--- a/libgearman-server/plugins/queue/redis/queue.cc
+++ b/libgearman-server/plugins/queue/redis/queue.cc
@@ -129,12 +129,15 @@ gearmand_error_t Hiredis::initialize()
   if (password.size())
   {
 	  redisReply *reply = (redisReply*)redisCommand(_redis, "AUTH %s", password.c_str());
-	  if (reply->type == REDIS_REPLY_ERROR)
+	  if (reply == NULL)
 	  {
 		  freeReplyObject(reply);
-		  return gearmand_log_gerror(GEARMAN_DEFAULT_LOG_PARAM,GEARMAND_QUEUE_ERROR,"Could not auth with redis server,hires auth reply: %.*s",(uint32_t)reply->len, reply->str);
+		  return gearmand_log_gerror(
+		  GEARMAN_DEFAULT_LOG_PARAM,
+		  GEARMAND_QUEUE_ERROR,
+		  "Could not auth with redis server,hires auth reply: %.*s",(uint32_t)reply->len, reply->str);
 	  }
-	  gearmand_log_debug(GEARMAN_DEFAULT_LOG_PARAM, "Auth success");
+	  gearmand_info(GEARMAN_DEFAULT_LOG_PARAM, "Auth success");
 
 	  freeReplyObject(reply);
   }

--- a/libgearman-server/plugins/queue/redis/queue.cc
+++ b/libgearman-server/plugins/queue/redis/queue.cc
@@ -131,9 +131,11 @@ gearmand_error_t Hiredis::initialize()
 	  redisReply *reply = (redisReply*)redisCommand(_redis, "AUTH %s", password.c_str());
 	  if (reply->type == REDIS_REPLY_ERROR)
 	  {
-		  return gearmand_gerror("Could not auth with redis server", GEARMAND_QUEUE_ERROR);
+		  freeReplyObject(reply);
+		  return gearmand_log_gerror(GEARMAN_DEFAULT_LOG_PARAM,GEARMAND_QUEUE_ERROR,"Could not auth with redis server,hires auth reply: %.*s",(uint32_t)reply->len, reply->str);
 	  }
-	  gearmand_log_debug(GEARMAN_DEFAULT_LOG_PARAM, "hires auth reply: %.*s", (uint32_t)reply->len, reply->str);
+	  gearmand_log_debug(GEARMAN_DEFAULT_LOG_PARAM, "Auth success");
+
 	  freeReplyObject(reply);
   }
 

--- a/libgearman-server/plugins/queue/redis/queue.cc
+++ b/libgearman-server/plugins/queue/redis/queue.cc
@@ -131,15 +131,24 @@ gearmand_error_t Hiredis::initialize()
 	  redisReply *reply = (redisReply*)redisCommand(_redis, "AUTH %s", password.c_str());
 	  if (reply == NULL)
 	  {
-		  freeReplyObject(reply);
 		  return gearmand_log_gerror(
 		  GEARMAN_DEFAULT_LOG_PARAM,
 		  GEARMAND_QUEUE_ERROR,
-		  "Could not auth with redis server,hires auth reply: %.*s",(uint32_t)reply->len, reply->str);
-	  }
-	  gearmand_log_debug(GEARMAN_DEFAULT_LOG_PARAM, "Auth success");
-
-	  freeReplyObject(reply);
+		  "Faild to auth with redis server error");
+	  } else {
+	      if(reply->type == REDIS_REPLY_ERROR) {
+          char *reply_str = reply->str;
+		  uint32_t reply_len = (uint32_t)reply->len;
+          freeReplyObject(reply);
+		  
+		  return gearmand_log_gerror(
+			GEARMAN_DEFAULT_LOG_PARAM,
+			GEARMAND_QUEUE_ERROR,
+		    "Could not auth with redis server,hires auth reply: %.*s",reply_len, reply_str);
+        }
+    }
+    freeReplyObject(reply);
+	gearmand_log_debug(GEARMAN_DEFAULT_LOG_PARAM, "Auth success");
   }
 
   gearmand_info("Initializing hiredis module");

--- a/libgearman-server/plugins/queue/redis/queue.cc
+++ b/libgearman-server/plugins/queue/redis/queue.cc
@@ -93,6 +93,7 @@ public:
 
   std::string server;
   std::string service;
+  std::string password;
 
 private:
   redisContext *_redis;
@@ -106,7 +107,8 @@ Hiredis::Hiredis() :
 {
   command_line_options().add_options()
     ("redis-server", boost::program_options::value(&server), "Redis server")
-    ("redis-port", boost::program_options::value(&service), "Redis server port/service");
+    ("redis-port", boost::program_options::value(&service), "Redis server port/service")
+	("redis-password", boost::program_options::value(&password), "Redis server password/service");
 }
 
 Hiredis::~Hiredis()
@@ -122,6 +124,17 @@ gearmand_error_t Hiredis::initialize()
       GEARMAN_DEFAULT_LOG_PARAM,
       GEARMAND_QUEUE_ERROR,
       "Could not connect to redis server: %s", _redis->errstr);
+  }
+
+  if (password.size())
+  {
+	  redisReply *reply = (redisReply*)redisCommand(_redis, "AUTH %s", password.c_str());
+	  if (reply == NULL)
+	  {
+		  return gearmand_gerror("Could not auth with redis server", GEARMAND_QUEUE_ERROR);
+	  }
+	  gearmand_log_debug(GEARMAN_DEFAULT_LOG_PARAM, "hires auth reply: %.*s", (uint32_t)reply->len, reply->str);
+	  freeReplyObject(reply);
   }
 
   gearmand_info("Initializing hiredis module");

--- a/libgearman-server/plugins/queue/redis/queue.cc
+++ b/libgearman-server/plugins/queue/redis/queue.cc
@@ -137,7 +137,7 @@ gearmand_error_t Hiredis::initialize()
 		  GEARMAND_QUEUE_ERROR,
 		  "Could not auth with redis server,hires auth reply: %.*s",(uint32_t)reply->len, reply->str);
 	  }
-	  gearmand_info(GEARMAN_DEFAULT_LOG_PARAM, "Auth success");
+	  gearmand_log_debug(GEARMAN_DEFAULT_LOG_PARAM, "Auth success");
 
 	  freeReplyObject(reply);
   }

--- a/libgearman-server/plugins/queue/redis/queue.cc
+++ b/libgearman-server/plugins/queue/redis/queue.cc
@@ -132,19 +132,18 @@ gearmand_error_t Hiredis::initialize()
 	  if (reply == NULL)
 	  {
 		  return gearmand_log_gerror(
-		  GEARMAN_DEFAULT_LOG_PARAM,
-		  GEARMAND_QUEUE_ERROR,
-		  "Faild to auth with redis server error");
-	  } else {
-	      if(reply->type == REDIS_REPLY_ERROR) {
-          char *reply_str = reply->str;
-		  uint32_t reply_len = (uint32_t)reply->len;
-          freeReplyObject(reply);
-		  
-		  return gearmand_log_gerror(
 			GEARMAN_DEFAULT_LOG_PARAM,
 			GEARMAND_QUEUE_ERROR,
-		    "Could not auth with redis server,hires auth reply: %.*s",reply_len, reply_str);
+			"Faild to auth with redis server error");
+	  } else {
+		  if(reply->type == REDIS_REPLY_ERROR) {
+			  char *reply_str = reply->str;
+			  freeReplyObject(reply);
+			  
+			  return gearmand_log_gerror(
+				GEARMAN_DEFAULT_LOG_PARAM,
+				GEARMAND_QUEUE_ERROR,
+				"Could not auth with redis server,hires auth reply: *s", reply_str);
         }
     }
     freeReplyObject(reply);

--- a/libgearman-server/plugins/queue/redis/queue.cc
+++ b/libgearman-server/plugins/queue/redis/queue.cc
@@ -129,18 +129,17 @@ gearmand_error_t Hiredis::initialize()
   if (password.size())
   {
     redisReply *reply = (redisReply*)redisCommand(_redis, "AUTH %s", password.c_str());
-    if(strcasecmp(reply->str,"OK") != 0)
-    {
-        char *error_str = reply->str;
-        freeReplyObject(reply);
+    if(reply == NULL || reply->type == REDIS_REPLY_ERROR) 
+      {
+           freeReplyObject(reply);
            
-        return gearmand_log_gerror(
-        GEARMAN_DEFAULT_LOG_PARAM,
-        GEARMAND_QUEUE_ERROR,
-        "Could not auth with redis server,and reply: %s", error_str);
-    } 
-    freeReplyObject(reply);
-    gearmand_log_debug(GEARMAN_DEFAULT_LOG_PARAM, "Auth success");
+           return gearmand_log_gerror(
+           GEARMAN_DEFAULT_LOG_PARAM,
+           GEARMAND_QUEUE_ERROR,
+           "Could not auth with redis server,hires auth reply: %s", _redis->errstr);
+      } 
+      freeReplyObject(reply);
+      gearmand_log_debug(GEARMAN_DEFAULT_LOG_PARAM, "Auth success");
   }
 
   gearmand_info("Initializing hiredis module");

--- a/libgearman-server/plugins/queue/redis/queue.cc
+++ b/libgearman-server/plugins/queue/redis/queue.cc
@@ -128,16 +128,16 @@ gearmand_error_t Hiredis::initialize()
 
   if (password.size())
   {
-      redisReply *reply = (redisReply*)redisCommand(_redis, "AUTH %s", password.c_str());
-    if(reply !=NULL && reply->type == REDIS_REPLY_ERROR) 
+    redisReply *reply = (redisReply*)redisCommand(_redis, "AUTH %s", password.c_str());
+    if(reply == NULL || reply->type == REDIS_REPLY_ERROR) 
       {
-          freeReplyObject(reply);
-          
-          return gearmand_log_gerror(
-            GEARMAN_DEFAULT_LOG_PARAM,
-            GEARMAND_QUEUE_ERROR,
-            "Could not auth with redis server,hires auth reply: %s", _redis->errstr);
-      }
+           freeReplyObject(reply);
+           
+           return gearmand_log_gerror(
+           GEARMAN_DEFAULT_LOG_PARAM,
+           GEARMAND_QUEUE_ERROR,
+           "Could not auth with redis server,hires auth reply: %s", _redis->errstr);
+      } 
       freeReplyObject(reply);
       gearmand_log_debug(GEARMAN_DEFAULT_LOG_PARAM, "Auth success");
   }

--- a/libgearman-server/plugins/queue/redis/queue.cc
+++ b/libgearman-server/plugins/queue/redis/queue.cc
@@ -129,25 +129,17 @@ gearmand_error_t Hiredis::initialize()
   if (password.size())
   {
       redisReply *reply = (redisReply*)redisCommand(_redis, "AUTH %s", password.c_str());
-      if (reply == NULL)
+    if(reply !=NULL && reply->type == REDIS_REPLY_ERROR) 
       {
+          freeReplyObject(reply);
+          
           return gearmand_log_gerror(
             GEARMAN_DEFAULT_LOG_PARAM,
             GEARMAND_QUEUE_ERROR,
-            "Faild to auth with redis server error reply: %s", _redis->errstr);
-      } else {
-          if(reply->type == REDIS_REPLY_ERROR) {
-              char *reply_str = reply->str;
-              freeReplyObject(reply);
-              
-              return gearmand_log_gerror(
-                GEARMAN_DEFAULT_LOG_PARAM,
-                GEARMAND_QUEUE_ERROR,
-                "Could not auth with redis server,hires auth reply: *s", reply_str);
-        }
-    }
-    freeReplyObject(reply);
-    gearmand_log_debug(GEARMAN_DEFAULT_LOG_PARAM, "Auth success");
+            "Could not auth with redis server,hires auth reply: %s", _redis->errstr);
+      }
+      freeReplyObject(reply);
+      gearmand_log_debug(GEARMAN_DEFAULT_LOG_PARAM, "Auth success");
   }
 
   gearmand_info("Initializing hiredis module");

--- a/libgearman-server/plugins/queue/redis/queue.cc
+++ b/libgearman-server/plugins/queue/redis/queue.cc
@@ -129,7 +129,7 @@ gearmand_error_t Hiredis::initialize()
   if (password.size())
   {
 	  redisReply *reply = (redisReply*)redisCommand(_redis, "AUTH %s", password.c_str());
-	  if (reply == NULL)
+	  if (reply->type == REDIS_REPLY_ERROR)
 	  {
 		  return gearmand_gerror("Could not auth with redis server", GEARMAND_QUEUE_ERROR);
 	  }

--- a/libgearman-server/plugins/queue/redis/queue.cc
+++ b/libgearman-server/plugins/queue/redis/queue.cc
@@ -129,17 +129,18 @@ gearmand_error_t Hiredis::initialize()
   if (password.size())
   {
     redisReply *reply = (redisReply*)redisCommand(_redis, "AUTH %s", password.c_str());
-    if(reply == NULL || reply->type == REDIS_REPLY_ERROR) 
-      {
-           freeReplyObject(reply);
+    if(strcasecmp(reply->str,"OK") != 0)
+    {
+        char *error_str = reply->str;
+        freeReplyObject(reply);
            
-           return gearmand_log_gerror(
-           GEARMAN_DEFAULT_LOG_PARAM,
-           GEARMAND_QUEUE_ERROR,
-           "Could not auth with redis server,hires auth reply: %s", _redis->errstr);
-      } 
-      freeReplyObject(reply);
-      gearmand_log_debug(GEARMAN_DEFAULT_LOG_PARAM, "Auth success");
+        return gearmand_log_gerror(
+        GEARMAN_DEFAULT_LOG_PARAM,
+        GEARMAND_QUEUE_ERROR,
+        "Could not auth with redis server,and reply: %s", error_str);
+    } 
+    freeReplyObject(reply);
+    gearmand_log_debug(GEARMAN_DEFAULT_LOG_PARAM, "Auth success");
   }
 
   gearmand_info("Initializing hiredis module");

--- a/libgearman-server/plugins/queue/redis/queue.cc
+++ b/libgearman-server/plugins/queue/redis/queue.cc
@@ -108,7 +108,7 @@ Hiredis::Hiredis() :
   command_line_options().add_options()
     ("redis-server", boost::program_options::value(&server), "Redis server")
     ("redis-port", boost::program_options::value(&service), "Redis server port/service")
-	("redis-password", boost::program_options::value(&password), "Redis server password/service");
+    ("redis-password", boost::program_options::value(&password), "Redis server password/service");
 }
 
 Hiredis::~Hiredis()
@@ -128,26 +128,26 @@ gearmand_error_t Hiredis::initialize()
 
   if (password.size())
   {
-	  redisReply *reply = (redisReply*)redisCommand(_redis, "AUTH %s", password.c_str());
-	  if (reply == NULL)
-	  {
-		  return gearmand_log_gerror(
-			GEARMAN_DEFAULT_LOG_PARAM,
-			GEARMAND_QUEUE_ERROR,
-			"Faild to auth with redis server error");
-	  } else {
-		  if(reply->type == REDIS_REPLY_ERROR) {
-			  char *reply_str = reply->str;
-			  freeReplyObject(reply);
-			  
-			  return gearmand_log_gerror(
-				GEARMAN_DEFAULT_LOG_PARAM,
-				GEARMAND_QUEUE_ERROR,
-				"Could not auth with redis server,hires auth reply: *s", reply_str);
+      redisReply *reply = (redisReply*)redisCommand(_redis, "AUTH %s", password.c_str());
+      if (reply == NULL)
+      {
+          return gearmand_log_gerror(
+            GEARMAN_DEFAULT_LOG_PARAM,
+            GEARMAND_QUEUE_ERROR,
+            "Faild to auth with redis server error reply: %s", _redis->errstr);
+      } else {
+          if(reply->type == REDIS_REPLY_ERROR) {
+              char *reply_str = reply->str;
+              freeReplyObject(reply);
+              
+              return gearmand_log_gerror(
+                GEARMAN_DEFAULT_LOG_PARAM,
+                GEARMAND_QUEUE_ERROR,
+                "Could not auth with redis server,hires auth reply: *s", reply_str);
         }
     }
     freeReplyObject(reply);
-	gearmand_log_debug(GEARMAN_DEFAULT_LOG_PARAM, "Auth success");
+    gearmand_log_debug(GEARMAN_DEFAULT_LOG_PARAM, "Auth success");
   }
 
   gearmand_info("Initializing hiredis module");


### PR DESCRIPTION
Hi
Gearmand can use redis as persistence queue , but It's connect redis only support  "redis-host" and "redis-port" options, And some redis servers must be accessed through authorization ,  So i add "redis-password" to connect redis.