### PR TITLE
Use _exit() in fork test to fix race

### DIFF
--- a/tests/libgearman-1.0/fork.cc
+++ b/tests/libgearman-1.0/fork.cc
@@ -79,9 +79,9 @@ test_return_t check_client_fork_TEST(void*)
           if (gearman_failed(ret= gearman_client_echo(&client, test_literal_param("child forked"))))
           {
             Error << gearman_client_error(&client);
-            exit(int(ret));
+            _exit(int(ret));
           }
-          exit(0);
+          _exit(0);
         }
 
       default:


### PR DESCRIPTION
Been doing some analysis. So what happens is this:

  1) child forks, which ends up with the same socket for both child and parent.
  1-parent) parent calls waitpid to wait for child to exit
  2) child successfully echoes
  3) child calls exit() which calls some registered atexit handler which
     shuts down the shared connection
  4) parent wakes up, sees client was successful, tries to use the same
     connection socket which was just shut down.

I don't know how this test worked ever. But most likely there was a race
between the SIGCHLD and the exit handlers, and that may have been fixed
in recent libc's.

Closes #44