### PR TITLE
Work around problems with ports in t/cycle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
           packages:
             - gcc-4.9
             - g++-4.9
+        artifacts: true
       env: COMPILER=g++-4.9
     - compiler: gcc
       addons:
@@ -21,6 +22,7 @@ matrix:
           packages:
             - gcc-5
             - g++-5
+        artifacts: true
       env: COMPILER=g++-5
 
 before_install:

--- a/libgearman-server/gearmand.cc
+++ b/libgearman-server/gearmand.cc
@@ -578,7 +578,7 @@ gearmand_error_t set_socket(gearmand_st* gearmand, int& fd, struct addrinfo *add
   return GEARMAND_SUCCESS;
 }
 
-static const uint32_t bind_timeout= 20; // Number is not special, but look at INFO messages if you decide to change it.
+static const uint32_t bind_timeout= 40; // Number is not special, but look at INFO messages if you decide to change it.
 
 typedef std::pair<std::string, std::string> host_port_t;
 
@@ -697,7 +697,7 @@ static gearmand_error_t _listen_init(gearmand_st *gearmand)
         this_wait= retry * retry / 3 + 1;
 
         // We are in single user threads, so strerror() is fine.
-        gearmand_log_debug(GEARMAN_DEFAULT_LOG_PARAM, "Retrying bind(%s) on %s:%s %u + %u >= %u", 
+        gearmand_log_info(GEARMAN_DEFAULT_LOG_PARAM, "Retrying bind(%s) on %s:%s %u + %u >= %u",
                            strerror(ret), host, port->port,
                            waited, this_wait, bind_timeout);
 


### PR DESCRIPTION
The comments in this code suggest that a busy server can run into
problems and that's why the code retries up to 20 times. I've raised
that to 30 to deal with frequent failures in Travis CI.

We also change the Retry to info, instead of debug, as that is useful
information for a system administrator while the daemon starts up, and
should not be relegated to debug-only logs.

This closes #50