### PR TITLE
http protocol unpack: default unique_size should be 1 instead of 2

### DIFF
--- a/libgearman-server/plugins/protocol/http/protocol.cc
+++ b/libgearman-server/plugins/protocol/http/protocol.cc
@@ -276,7 +276,7 @@ public:
                 gearmand_error_t& ret_ptr)
   {
     const char *unique= "-";
-    size_t unique_size= 2;
+    size_t unique_size= 1;
     gearman_job_priority_t priority= GEARMAN_JOB_PRIORITY_NORMAL;
 
     gearmand_info("Receiving HTTP response");


### PR DESCRIPTION
libgearman-server/plugins/http/protocol:unpack

refer to line 542:

      if ((ret_ptr= gearmand_packet_create(packet, unique, unique_size +1)) != GEARMAND_SUCCESS)
