### PR TITLE
Added configure options to bootstrap.sh arguments

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1113,7 +1113,7 @@ run ()
 
 parse_command_line_options ()
 {
-  local SHORTOPTS=':apcmt:dvh'
+  local SHORTOPTS=':apcmt:dvho:'
 
   nassert OPT_TARGET
 


### PR DESCRIPTION
It was forgotten to add that shortopt so even if the help said you could specify the options for the configure phase, it was not true.
Calling ./bootstrap.sh -c -o "--prefix=my/dir" would print "error - unrecognized option -o"