### PR TITLE
ISSUE #141 Gearmand docs not visible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ man/*.1
 man/*.3
 man/*.8
 man/.doctrees/
+nbproject/
 patch
 scripts/gearmand
 scripts/gearmand-init

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,12 @@
+branches:
+  only:
+    - master
+    - gh-pages
+
+cache:
+  directories:
+    - docs/dev
+
 language: cpp
 dist: trusty
 sudo: required
@@ -43,3 +52,13 @@ script:
   - ./configure
   - make
   - make test
+  - rm -Rf docs/dev
+  - mv docs/build docs/dev
+  
+deploy:
+  provider: pages                                                                                                                   
+  skip_cleanup: true
+  github_token: $GITHUB_TOKEN
+  on:
+    branch: gh-pages
+  target_branch: gh-pages


### PR DESCRIPTION
I am not certain if this MR will close that issue. Truth to be told the flow where each commit (no matter if only updating docs or creating relevant change in sources) both application sources and documentation should be built.

Result is visible here: https://basbastian.github.io/gearmand/docs/dev/html/
Deployment result is visible also on my gh-pages branch in repository https://github.com/BasBastian/gearmand 