### PR TITLE
Remove osx from travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 os:
   - linux
-  - osx
 language: cpp
 dist: trusty
 sudo: required


### PR DESCRIPTION
Once again the magic fairies that make OS X + Boost + Gearmand work have
failed me. I see that brew has it working, so I would appreciate any
help from whoever it is that maintains that formula to re-enable this.

For now, it's holding us back. :(