### PR TITLE
free task->send.data which is never freed

### DIFF
--- a/libgearman/add.cc
+++ b/libgearman/add.cc
@@ -322,6 +322,7 @@ gearman_task_st *add_task(Client& client,
     break;
   }
 
+  free((void *)(task->send.data));
   if (gearman_success(rc))
   {
     client.new_tasks++;


### PR DESCRIPTION
https://github.com/gearman/gearmand/issues/163
if anyone just check the code, task->send.data , that send.data should come from libgearman/packet.cc line 90:
packet->data= gearman_malloc(*packet->universal, arg_size);
( I am not 100% sure because it's been 20 days and I didn't log my analysis, I did my best to search code it looks familiar to me. )
and if you check where is the code to free packet->data , there is none.
that's why I just add a free here.

I hesitate to create a PR is because I thought there should be a better way to fix this. 
at least probably check if that send.data is already freed. if not, free it.

Clint Byrum encouraged me to create the PR, so I did. if anyone think the fix should be better, go ahead.
