### PR TITLE
Boostrap.sh can't handle openSUSE Tumbleweed

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -191,7 +191,7 @@ set_VENDOR_DISTRIBUTION ()
     suse)
       VENDOR_DISTRIBUTION='opensuse'
       ;;
-    opensuse)
+    opensuse*)
       VENDOR_DISTRIBUTION='opensuse'
       ;;
     *)
@@ -307,7 +307,7 @@ set_VENDOR ()
     debian)
       VENDOR='debian'
       ;;
-    opensuse)
+    opensuse*)
       VENDOR='suse'
       ;;
     suse)


### PR DESCRIPTION
Boostrap.sh Doesn't recognize openSUSE Tubleweed because it has name 'opensuse-tumbleweed' not just 'opensuse' as it expects.