### PR TITLE
Fix fallthrough warning in log.cc

### DIFF
--- a/libgearman-server/log.cc
+++ b/libgearman-server/log.cc
@@ -123,11 +123,11 @@ static gearmand_error_t __errno_to_gearmand_error_t(int local_errno)
   switch (local_errno)
   {
   case ENOMEM:
-    error_to_report = GEARMAND_MEMORY_ALLOCATION_FAILURE;
+    error_to_report= GEARMAND_MEMORY_ALLOCATION_FAILURE;
     break;
   case ECONNRESET:
   case EHOSTDOWN:
-    error_to_report = GEARMAND_LOST_CONNECTION;
+    error_to_report= GEARMAND_LOST_CONNECTION;
     break;
   default:
     break;

--- a/libgearman-server/log.cc
+++ b/libgearman-server/log.cc
@@ -123,12 +123,12 @@ static gearmand_error_t __errno_to_gearmand_error_t(int local_errno)
   switch (local_errno)
   {
   case ENOMEM:
-    error_to_report= GEARMAND_MEMORY_ALLOCATION_FAILURE;
-
+    error_to_report = GEARMAND_MEMORY_ALLOCATION_FAILURE;
+    break;
   case ECONNRESET:
   case EHOSTDOWN:
-    error_to_report= GEARMAND_LOST_CONNECTION;
-
+    error_to_report = GEARMAND_LOST_CONNECTION;
+    break;
   default:
     break;
   }


### PR DESCRIPTION
This one fixes one fall through warning in log.cc which compiler picks up separated from PR #114 