### PR TITLE
Fix strncpy problem in libgearman-server/gearmand.cc

### DIFF
--- a/libgearman-server/gearmand.cc
+++ b/libgearman-server/gearmand.cc
@@ -322,7 +322,8 @@ gearmand_error_t gearmand_port_add(gearmand_st *gearmand, const char *port,
   assert(gearmand);
   gearmand->_port_list.resize(gearmand->_port_list.size() +1);
 
-  strncpy(gearmand->_port_list.back().port, port, NI_MAXSERV);
+  memcpy(gearmand->_port_list.back().port, port, NI_MAXSERV);
+  gearmand->_port_list.back().port[NI_MAXSERV -1]= '\0';
   gearmand->_port_list.back().add_fn(function);
   gearmand->_port_list.back().remove_fn(remove_);
 


### PR DESCRIPTION
This is pragmatic way of solving problem: 
```libgearman-server/gearmand.cc: In function ‘gearmand_error_t 
gearmand_port_add(gearmand_st*, const char*, gearmand_error_t (*)(gearman_server_con_st*), gearmand_error_t (*)(gearman_server_con_st*))’:
libgearman-server/gearmand.cc:325:10: error: ‘char* strncpy(char*, const char*, size_t)’ specified bound 32 equals destination size [-Werror=stringop-truncation]
   strncpy(gearmand->_port_list.back().port, port, NI_MAXSERV);
```

Which is new GCC7/8 warning