### PR TITLE
Turn new GCC 7 errors to warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,17 @@ matrix:
         artifacts: true
       env:
         - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-7
+            - g++-7
+        artifacts: true
+      env:
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
 
 before_install:
   - eval "${MATRIX_EVAL}"

--- a/libgearman-server/io.cc
+++ b/libgearman-server/io.cc
@@ -572,7 +572,9 @@ gearmand_con_st *gearman_io_context(const gearmand_io_st *connection)
   return connection->context;
 }
 
-#pragma GCC diagnostic warning "-Wimplicit-fallthrough"
+#if __GNUC__ >= 7
+  #pragma GCC diagnostic warning "-Wimplicit-fallthrough"
+#endif
 gearmand_error_t gearman_io_send(gearman_server_con_st *con,
                                  const gearmand_packet_st *packet, bool flush)
 {

--- a/libgearman-server/io.cc
+++ b/libgearman-server/io.cc
@@ -572,6 +572,7 @@ gearmand_con_st *gearman_io_context(const gearmand_io_st *connection)
   return connection->context;
 }
 
+#pragma GCC diagnostic warning "-Wimplicit-fallthrough"
 gearmand_error_t gearman_io_send(gearman_server_con_st *con,
                                  const gearmand_packet_st *packet, bool flush)
 {

--- a/libgearman-server/log.cc
+++ b/libgearman-server/log.cc
@@ -116,6 +116,7 @@ gearmand_error_t gearmand_initialize_thread_logging(const char *identity)
   return GEARMAND_INVALID_ARGUMENT;
 }
 
+#pragma GCC diagnostic warning "-Wimplicit-fallthrough"
 static gearmand_error_t __errno_to_gearmand_error_t(int local_errno)
 {
   gearmand_error_t error_to_report= GEARMAND_ERRNO;

--- a/libgearman-server/log.cc
+++ b/libgearman-server/log.cc
@@ -116,7 +116,9 @@ gearmand_error_t gearmand_initialize_thread_logging(const char *identity)
   return GEARMAND_INVALID_ARGUMENT;
 }
 
-#pragma GCC diagnostic warning "-Wimplicit-fallthrough"
+#if __GNUC__ >= 7
+  #pragma GCC diagnostic warning "-Wimplicit-fallthrough"
+#endif
 static gearmand_error_t __errno_to_gearmand_error_t(int local_errno)
 {
   gearmand_error_t error_to_report= GEARMAND_ERRNO;

--- a/libgearman-server/server.cc
+++ b/libgearman-server/server.cc
@@ -100,7 +100,6 @@ _server_queue_work_data(gearman_server_job_st *server_job,
  * Public definitions
  */
 
-
 #if __GNUC__ >= 7
   #pragma GCC diagnostic warning "-Wimplicit-fallthrough"
 #endif

--- a/libgearman-server/server.cc
+++ b/libgearman-server/server.cc
@@ -100,6 +100,8 @@ _server_queue_work_data(gearman_server_job_st *server_job,
  * Public definitions
  */
 
+
+#pragma GCC diagnostic warning "-Wimplicit-fallthrough"
 gearmand_error_t gearman_server_run_command(gearman_server_con_st *server_con,
                                             gearmand_packet_st *packet)
 {

--- a/libgearman-server/server.cc
+++ b/libgearman-server/server.cc
@@ -101,7 +101,9 @@ _server_queue_work_data(gearman_server_job_st *server_job,
  */
 
 
-#pragma GCC diagnostic warning "-Wimplicit-fallthrough"
+#if __GNUC__ >= 7
+  #pragma GCC diagnostic warning "-Wimplicit-fallthrough"
+#endif
 gearmand_error_t gearman_server_run_command(gearman_server_con_st *server_con,
                                             gearmand_packet_st *packet)
 {

--- a/libgearman/connection.cc
+++ b/libgearman/connection.cc
@@ -464,6 +464,7 @@ gearman_return_t gearman_connection_st::send_packet(const gearman_packet_st& pac
  * This is the real implementation that actually sends a packet. Read the comments for send_packet() for why
  * that is. Note that this is a private method. External callers should only call send_packet().
  */
+#pragma GCC diagnostic warning "-Wimplicit-fallthrough"
 gearman_return_t gearman_connection_st::_send_packet(const gearman_packet_st& packet_arg, const bool flush_buffer)
 {
   switch (send_state)
@@ -684,6 +685,7 @@ gearman_return_t gearman_connection_st::enable_ssl()
   return GEARMAN_SUCCESS;
 }
 
+#pragma GCC diagnostic warning "-Wimplicit-fallthrough"
 gearman_return_t gearman_connection_st::flush()
 {
   while (1)
@@ -954,6 +956,7 @@ gearman_return_t gearman_connection_st::flush()
   }
 }
 
+#pragma GCC diagnostic warning "-Wimplicit-fallthrough"
 gearman_packet_st *gearman_connection_st::receiving(gearman_packet_st& packet_arg,
                                                     gearman_return_t& ret,
                                                     const bool recv_data)

--- a/libgearman/connection.cc
+++ b/libgearman/connection.cc
@@ -464,7 +464,9 @@ gearman_return_t gearman_connection_st::send_packet(const gearman_packet_st& pac
  * This is the real implementation that actually sends a packet. Read the comments for send_packet() for why
  * that is. Note that this is a private method. External callers should only call send_packet().
  */
-#pragma GCC diagnostic warning "-Wimplicit-fallthrough"
+#if __GNUC__ >= 7
+  #pragma GCC diagnostic warning "-Wimplicit-fallthrough"
+#endif
 gearman_return_t gearman_connection_st::_send_packet(const gearman_packet_st& packet_arg, const bool flush_buffer)
 {
   switch (send_state)
@@ -685,7 +687,9 @@ gearman_return_t gearman_connection_st::enable_ssl()
   return GEARMAN_SUCCESS;
 }
 
-#pragma GCC diagnostic warning "-Wimplicit-fallthrough"
+#if __GNUC__ >= 7
+  #pragma GCC diagnostic warning "-Wimplicit-fallthrough"
+#endif
 gearman_return_t gearman_connection_st::flush()
 {
   while (1)
@@ -956,7 +960,9 @@ gearman_return_t gearman_connection_st::flush()
   }
 }
 
-#pragma GCC diagnostic warning "-Wimplicit-fallthrough"
+#if __GNUC__ >= 7
+  #pragma GCC diagnostic warning "-Wimplicit-fallthrough"
+#endif
 gearman_packet_st *gearman_connection_st::receiving(gearman_packet_st& packet_arg,
                                                     gearman_return_t& ret,
                                                     const bool recv_data)

--- a/libgearman/run.cc
+++ b/libgearman/run.cc
@@ -45,7 +45,9 @@
 #include <cstdlib>
 #include <cstring>
 
-#pragma GCC diagnostic warning "-Wimplicit-fallthrough"
+#if __GNUC__ >= 7
+  #pragma GCC diagnostic warning "-Wimplicit-fallthrough"
+#endif
 gearman_return_t _client_run_task(Task *task)
 {
   // This should not be possible

--- a/libgearman/run.cc
+++ b/libgearman/run.cc
@@ -45,6 +45,7 @@
 #include <cstdlib>
 #include <cstring>
 
+#pragma GCC diagnostic warning "-Wimplicit-fallthrough"
 gearman_return_t _client_run_task(Task *task)
 {
   // This should not be possible

--- a/libgearman/worker.cc
+++ b/libgearman/worker.cc
@@ -649,6 +649,7 @@ gearman_return_t gearman_worker_unregister_all(gearman_worker_st *worker_shell)
   return GEARMAN_INVALID_ARGUMENT;
 }
 
+#pragma GCC diagnostic warning "-Wimplicit-fallthrough"
 gearman_job_st *gearman_worker_grab_job(gearman_worker_st *worker_shell,
                                         gearman_job_st *job,
                                         gearman_return_t *ret_ptr)
@@ -1071,6 +1072,7 @@ void gearman_worker_reset_error(gearman_worker_st *worker)
   }
 }
 
+#pragma GCC diagnostic warning "-Wimplicit-fallthrough"
 gearman_return_t gearman_worker_work(gearman_worker_st *worker_shell)
 {
   if (worker_shell and worker_shell->impl())

--- a/libgearman/worker.cc
+++ b/libgearman/worker.cc
@@ -649,7 +649,9 @@ gearman_return_t gearman_worker_unregister_all(gearman_worker_st *worker_shell)
   return GEARMAN_INVALID_ARGUMENT;
 }
 
-#pragma GCC diagnostic warning "-Wimplicit-fallthrough"
+#if __GNUC__ >= 7
+  #pragma GCC diagnostic warning "-Wimplicit-fallthrough"
+#endif
 gearman_job_st *gearman_worker_grab_job(gearman_worker_st *worker_shell,
                                         gearman_job_st *job,
                                         gearman_return_t *ret_ptr)
@@ -1072,7 +1074,9 @@ void gearman_worker_reset_error(gearman_worker_st *worker)
   }
 }
 
-#pragma GCC diagnostic warning "-Wimplicit-fallthrough"
+#if __GNUC__ >= 7
+  #pragma GCC diagnostic warning "-Wimplicit-fallthrough"
+#endif
 gearman_return_t gearman_worker_work(gearman_worker_st *worker_shell)
 {
   if (worker_shell and worker_shell->impl())

--- a/libhashkit/jenkins.cc
+++ b/libhashkit/jenkins.cc
@@ -93,6 +93,7 @@ use a bitmask.  For example, if you need only 10 bits, do
 In which case, the hash table should have hashsize(10) elements.
 */
 
+#pragma GCC diagnostic warning "-Wimplicit-fallthrough"
 uint32_t hashkit_jenkins(const char *key, size_t length, void *)
 {
   uint32_t a,b,c;                                          /* internal state */

--- a/libhashkit/jenkins.cc
+++ b/libhashkit/jenkins.cc
@@ -93,7 +93,9 @@ use a bitmask.  For example, if you need only 10 bits, do
 In which case, the hash table should have hashsize(10) elements.
 */
 
-#pragma GCC diagnostic warning "-Wimplicit-fallthrough"
+#if __GNUC__ >= 7
+  #pragma GCC diagnostic warning "-Wimplicit-fallthrough"
+#endif
 uint32_t hashkit_jenkins(const char *key, size_t length, void *)
 {
   uint32_t a,b,c;                                          /* internal state */

--- a/libhashkit/murmur3.cc
+++ b/libhashkit/murmur3.cc
@@ -70,7 +70,9 @@ static FORCE_INLINE uint64_t fmix64 ( uint64_t k )
 
 //-----------------------------------------------------------------------------
 
-#pragma GCC diagnostic warning "-Wimplicit-fallthrough"
+#if __GNUC__ >= 7
+  #pragma GCC diagnostic warning "-Wimplicit-fallthrough"
+#endif
 void MurmurHash3_x86_32 ( const void * key, int len,
                           uint32_t seed, void * out )
 {
@@ -128,7 +130,9 @@ void MurmurHash3_x86_32 ( const void * key, int len,
 
 //-----------------------------------------------------------------------------
 
-#pragma GCC diagnostic warning "-Wimplicit-fallthrough"
+#if __GNUC__ >= 7
+  #pragma GCC diagnostic warning "-Wimplicit-fallthrough"
+#endif
 void MurmurHash3_x86_128 ( const void * key, const int len,
                            uint32_t seed, void * out )
 {
@@ -235,7 +239,9 @@ void MurmurHash3_x86_128 ( const void * key, const int len,
 
 //-----------------------------------------------------------------------------
 
-#pragma GCC diagnostic warning "-Wimplicit-fallthrough"
+#if __GNUC__ >= 7
+  #pragma GCC diagnostic warning "-Wimplicit-fallthrough"
+#endif
 void MurmurHash3_x64_128 ( const void * key, const int len,
                            const uint32_t seed, void * out )
 {

--- a/libhashkit/murmur3.cc
+++ b/libhashkit/murmur3.cc
@@ -70,6 +70,7 @@ static FORCE_INLINE uint64_t fmix64 ( uint64_t k )
 
 //-----------------------------------------------------------------------------
 
+#pragma GCC diagnostic warning "-Wimplicit-fallthrough"
 void MurmurHash3_x86_32 ( const void * key, int len,
                           uint32_t seed, void * out )
 {
@@ -127,6 +128,7 @@ void MurmurHash3_x86_32 ( const void * key, int len,
 
 //-----------------------------------------------------------------------------
 
+#pragma GCC diagnostic warning "-Wimplicit-fallthrough"
 void MurmurHash3_x86_128 ( const void * key, const int len,
                            uint32_t seed, void * out )
 {
@@ -233,6 +235,7 @@ void MurmurHash3_x86_128 ( const void * key, const int len,
 
 //-----------------------------------------------------------------------------
 
+#pragma GCC diagnostic warning "-Wimplicit-fallthrough"
 void MurmurHash3_x64_128 ( const void * key, const int len,
                            const uint32_t seed, void * out )
 {

--- a/libtest/main.cc
+++ b/libtest/main.cc
@@ -63,6 +63,7 @@ using namespace libtest;
 #include <getopt.h>
 #include <unistd.h>
 
+#pragma GCC diagnostic warning "-Wimplicit-fallthrough"
 int main(int argc, char *argv[], char* environ_[])
 {
   bool opt_massive= false;

--- a/libtest/main.cc
+++ b/libtest/main.cc
@@ -63,7 +63,9 @@ using namespace libtest;
 #include <getopt.h>
 #include <unistd.h>
 
-#pragma GCC diagnostic warning "-Wimplicit-fallthrough"
+#if __GNUC__ >= 7
+  #pragma GCC diagnostic warning "-Wimplicit-fallthrough"
+#endif
 int main(int argc, char *argv[], char* environ_[])
 {
   bool opt_massive= false;

--- a/tests/libgearman-1.0/worker_test.cc
+++ b/tests/libgearman-1.0/worker_test.cc
@@ -1636,7 +1636,9 @@ static test_return_t gearman_worker_set_identifier_TEST(void *)
   return TEST_SUCCESS;
 }
 
-#pragma GCC diagnostic warning "-Wformat-truncation"
+#if __GNUC__ >= 7
+  #pragma GCC diagnostic warning "-Wformat-truncation"
+#endif
 static test_return_t gearman_worker_add_options_GEARMAN_WORKER_GRAB_UNIQ_worker_work(void *)
 {
   libgearman::Worker worker(libtest::default_port());

--- a/tests/libgearman-1.0/worker_test.cc
+++ b/tests/libgearman-1.0/worker_test.cc
@@ -1636,6 +1636,7 @@ static test_return_t gearman_worker_set_identifier_TEST(void *)
   return TEST_SUCCESS;
 }
 
+#pragma GCC diagnostic warning "-Wformat-truncation"
 static test_return_t gearman_worker_add_options_GEARMAN_WORKER_GRAB_UNIQ_worker_work(void *)
 {
   libgearman::Worker worker(libtest::default_port());

--- a/util/instance.cc
+++ b/util/instance.cc
@@ -158,6 +158,7 @@ bool Instance::init_ssl()
   return true;
 }
 
+#pragma GCC diagnostic warning "-Wimplicit-fallthrough"
 bool Instance::run()
 {
   if (_use_ssl)

--- a/util/instance.cc
+++ b/util/instance.cc
@@ -158,7 +158,9 @@ bool Instance::init_ssl()
   return true;
 }
 
-#pragma GCC diagnostic warning "-Wimplicit-fallthrough"
+#if __GNUC__ >= 7
+  #pragma GCC diagnostic warning "-Wimplicit-fallthrough"
+#endif
 bool Instance::run()
 {
   if (_use_ssl)


### PR DESCRIPTION
In GCC 7+ some `-W` flags were added or changed their behavior and is causing the build to fail. This PR takes the somewhat lazy route of turning these errors into warnings instead to let it compile.

Tested on Ubuntu 18.04 with GCC 7.3.0, and on Travis here: https://travis-ci.com/defect/gearmand/builds/90657856