### PR TITLE
GCC8 tries to be more strict with type casting

### DIFF
--- a/libtest/thread.hpp
+++ b/libtest/thread.hpp
@@ -224,7 +224,7 @@ public:
   template <class Function,class Arg1>
     Thread(Function func, Arg1 arg):
       _joined(false),
-      _func((start_routine_fn)func),
+      _func((start_routine_fn)(void(*)())func),
       _context(arg)
     {
       int err;


### PR DESCRIPTION
needs to be redone as it fix:
  libtest/thread.hpp:227:13: error: cast between incompatible function types from ‘void (*)(context_st*)’
     to ‘libtest::thread::Thread::start_routine_fn’ {aka ‘void* (*)(void*)’} [-Werror=cast-function-type]