### PR TITLE
Add /* fall-thru */ to get rid of compiling fall through warnings

### DIFF
--- a/libgearman-server/io.cc
+++ b/libgearman-server/io.cc
@@ -668,6 +668,7 @@ gearmand_error_t gearman_io_send(gearman_server_con_st *con,
 
     /* Flush buffer now so we can start writing directly from data buffer. */
     connection->send_state= gearmand_io_st::GEARMAND_CON_SEND_UNIVERSAL_FORCE_FLUSH;
+    /* fall-thru */
 
   case gearmand_io_st::GEARMAND_CON_SEND_UNIVERSAL_FORCE_FLUSH:
     {
@@ -676,6 +677,7 @@ gearmand_error_t gearman_io_send(gearman_server_con_st *con,
       {
         return local_ret;
       }
+      /* fall-thru */
     }
 
     connection->send_data_size= packet->data_size;
@@ -701,6 +703,7 @@ gearmand_error_t gearman_io_send(gearman_server_con_st *con,
 
     connection->send_buffer_ptr= const_cast<char *>(packet->data) + connection->send_data_offset;
     connection->send_state= gearmand_io_st::GEARMAND_CON_SEND_UNIVERSAL_FLUSH_DATA;
+    /* fall-thru */
 
   case gearmand_io_st::GEARMAND_CON_SEND_UNIVERSAL_FLUSH:
   case gearmand_io_st::GEARMAND_CON_SEND_UNIVERSAL_FLUSH_DATA:
@@ -716,6 +719,7 @@ gearmand_error_t gearman_io_send(gearman_server_con_st *con,
       return local_ret;
     }
   }
+  /* fall-thru */
 
   if (flush)
   {
@@ -755,6 +759,7 @@ gearmand_error_t gearman_io_recv(gearman_server_con_st *con, bool recv_data)
     connection->recv_packet->reset(GEARMAN_MAGIC_TEXT, GEARMAN_COMMAND_TEXT);
 
     connection->recv_state= gearmand_io_st::GEARMAND_CON_RECV_UNIVERSAL_READ;
+    /* fall-thru */
 
   case gearmand_io_st::GEARMAND_CON_RECV_UNIVERSAL_READ:
     while (1)
@@ -833,6 +838,7 @@ gearmand_error_t gearman_io_recv(gearman_server_con_st *con, bool recv_data)
 
     packet->options.free_data= true;
     connection->recv_state= gearmand_io_st::GEARMAND_CON_RECV_STATE_READ_DATA;
+    /* fall-thru */
 
   case gearmand_io_st::GEARMAND_CON_RECV_STATE_READ_DATA:
     while (connection->recv_data_size)

--- a/libgearman-server/io.cc
+++ b/libgearman-server/io.cc
@@ -158,6 +158,7 @@ static size_t _connection_read(gearman_server_con_st *con, void *data, size_t da
             read_size= SOCKET_ERROR;
             break;
           }
+          /* fall-thru */
 
         case SSL_ERROR_SSL:
         default:
@@ -337,7 +338,8 @@ static gearmand_error_t _connection_flush(gearman_server_con_st *con)
                 write_size= SOCKET_ERROR;
                 break;
               }
-
+              /* fall-thru */
+              
             case SSL_ERROR_SSL:
             default:
               {

--- a/libgearman-server/server.cc
+++ b/libgearman-server/server.cc
@@ -144,6 +144,7 @@ gearmand_error_t gearman_server_run_command(gearman_server_con_st *server_con,
     {
       return GEARMAND_MEMORY_ALLOCATION_FAILURE;
     }
+    /* fall-thru */
 
   case GEARMAN_COMMAND_SUBMIT_REDUCE_JOB_BACKGROUND:
     {

--- a/libgearman/connection.cc
+++ b/libgearman/connection.cc
@@ -547,6 +547,7 @@ gearman_return_t gearman_connection_st::_send_packet(const gearman_packet_st& pa
 
     /* Flush buffer now so we can start writing directly from data buffer. */
     send_state= GEARMAN_CON_SEND_UNIVERSAL_FORCE_FLUSH;
+    /* fall-thru */
 
   case GEARMAN_CON_SEND_UNIVERSAL_FORCE_FLUSH:
     {
@@ -555,6 +556,7 @@ gearman_return_t gearman_connection_st::_send_packet(const gearman_packet_st& pa
       {
         return ret;
       }
+      /* fall-thru */
     }
 
     send_data_size= packet_arg.data_size;
@@ -580,6 +582,7 @@ gearman_return_t gearman_connection_st::_send_packet(const gearman_packet_st& pa
 
     send_buffer_ptr= (const char*)(size_t(packet_arg.data) +send_data_offset);
     send_state= GEARMAN_CON_SEND_UNIVERSAL_FLUSH_DATA;
+    /* fall-thru */
 
   case GEARMAN_CON_SEND_UNIVERSAL_FLUSH:
   case GEARMAN_CON_SEND_UNIVERSAL_FLUSH_DATA:
@@ -705,6 +708,7 @@ gearman_return_t gearman_connection_st::flush()
           return ret;
         }
       }
+      /* fall-thru */
 
     case GEARMAN_CON_UNIVERSAL_CONNECT:
       if (fd != INVALID_SOCKET)
@@ -760,6 +764,7 @@ gearman_return_t gearman_connection_st::flush()
         case ENETUNREACH:
         case ETIMEDOUT:
           addrinfo_next= addrinfo_next->ai_next;
+          /* fall-thru */
 
           // We will treat this as an error but retry the address
         case EAGAIN:
@@ -780,6 +785,7 @@ gearman_return_t gearman_connection_st::flush()
       {
         break;
       }
+      /* fall-thru */
 
     case GEARMAN_CON_UNIVERSAL_CONNECTING:
       while (1)
@@ -821,6 +827,7 @@ gearman_return_t gearman_connection_st::flush()
       {
         break;
       }
+      /* fall-thru */
 
     case GEARMAN_CON_UNIVERSAL_CONNECTED:
       while (send_buffer_size != 0)
@@ -986,6 +993,7 @@ gearman_packet_st *gearman_connection_st::receiving(gearman_packet_st& packet_ar
     }
 
     recv_state= GEARMAN_CON_RECV_UNIVERSAL_READ;
+    /* fall-thru */
 
   case GEARMAN_CON_RECV_UNIVERSAL_READ:
     while (1)
@@ -1056,6 +1064,7 @@ gearman_packet_st *gearman_connection_st::receiving(gearman_packet_st& packet_ar
 
     packet_arg.options.free_data= true;
     recv_state= GEARMAN_CON_RECV_STATE_READ_DATA;
+    /* fall-thru */
 
   case GEARMAN_CON_RECV_STATE_READ_DATA:
     while (recv_data_size)

--- a/libgearman/connection.cc
+++ b/libgearman/connection.cc
@@ -867,6 +867,7 @@ gearman_return_t gearman_connection_st::flush()
                 write_size= SOCKET_ERROR;
                 break;
               }
+            /* fall-thru */
 
             case SSL_ERROR_SSL:
             default:
@@ -1180,6 +1181,7 @@ size_t gearman_connection_st::recv_socket(void *data, size_t data_size, gearman_
             read_size= SOCKET_ERROR;
             break;
           }
+          /* fall-thru */
 
         case SSL_ERROR_SSL:
         default:

--- a/libgearman/run.cc
+++ b/libgearman/run.cc
@@ -93,6 +93,7 @@ gearman_return_t _client_run_task(Task *task)
       task->created_id= task->con->created_id_next;
       task->con->created_id_next++;
     }
+    /* fall-thru */
 
   case GEARMAN_TASK_STATE_SUBMIT:
     while (1)

--- a/libgearman/worker.cc
+++ b/libgearman/worker.cc
@@ -788,6 +788,7 @@ gearman_job_st *gearman_worker_grab_job(gearman_worker_st *worker_shell,
                 continue;
               }
             }
+            /* fall-thru */
 
             case GEARMAN_WORKER_STATE_GRAB_JOB_SEND:
             if (worker->con->socket_descriptor_is_valid() == false)
@@ -825,6 +826,7 @@ gearman_job_st *gearman_worker_grab_job(gearman_worker_st *worker_shell,
 
             while (1)
             {
+              /* fall-thru */
               case GEARMAN_WORKER_STATE_GRAB_JOB_RECV:
                 assert(worker);
                 assert(worker->job());
@@ -897,6 +899,7 @@ gearman_job_st *gearman_worker_grab_job(gearman_worker_st *worker_shell,
             *ret_ptr= GEARMAN_NO_JOBS;
             break;
           }
+          /* fall-thru */
 
         case GEARMAN_WORKER_STATE_PRE_SLEEP:
           for (worker->con= (&worker->universal)->con_list; worker->con;
@@ -1129,6 +1132,7 @@ gearman_return_t gearman_worker_work(gearman_worker_st *worker_shell)
 
           worker->work_result_size= 0;
         }
+        /* fall-thru */
 
       case GEARMAN_WORKER_WORK_UNIVERSAL_FUNCTION:
         {
@@ -1161,6 +1165,7 @@ gearman_return_t gearman_worker_work(gearman_worker_st *worker_shell)
             break;
           }
         }
+        /* fall-thru */
 
       case GEARMAN_WORKER_WORK_UNIVERSAL_COMPLETE:
         {

--- a/libhashkit/jenkins.cc
+++ b/libhashkit/jenkins.cc
@@ -230,17 +230,17 @@ uint32_t hashkit_jenkins(const char *key, size_t length, void *)
     /*-------------------------------- last block: affect all 32 bits of (c) */
     switch(length)                   /* all the case statements fall through */
     {
-    case 12: c+=((uint32_t)k[11])<<24; /* fall-thru */
-    case 11: c+=((uint32_t)k[10])<<16; /* fall-thru */
-    case 10: c+=((uint32_t)k[9])<<8; /* fall-thru */
-    case 9 : c+=k[8]; /* fall-thru */
-    case 8 : b+=((uint32_t)k[7])<<24; /* fall-thru */
-    case 7 : b+=((uint32_t)k[6])<<16; /* fall-thru */
-    case 6 : b+=((uint32_t)k[5])<<8; /* fall-thru */
-    case 5 : b+=k[4]; /* fall-thru */
-    case 4 : a+=((uint32_t)k[3])<<24; /* fall-thru */
-    case 3 : a+=((uint32_t)k[2])<<16; /* fall-thru */
-    case 2 : a+=((uint32_t)k[1])<<8; /* fall-thru */
+    case 12: c+=((uint32_t)k[11])<<24; /* fall through */
+    case 11: c+=((uint32_t)k[10])<<16; /* fall through */
+    case 10: c+=((uint32_t)k[9])<<8; /* fall through */
+    case 9 : c+=k[8]; /* fall through */
+    case 8 : b+=((uint32_t)k[7])<<24; /* fall through */
+    case 7 : b+=((uint32_t)k[6])<<16; /* fall through */
+    case 6 : b+=((uint32_t)k[5])<<8; /* fall through */
+    case 5 : b+=k[4]; /* fall through */
+    case 4 : a+=((uint32_t)k[3])<<24; /* fall through */
+    case 3 : a+=((uint32_t)k[2])<<16; /* fall through */
+    case 2 : a+=((uint32_t)k[1])<<8; /* fall through */
     case 1 : a+=k[0];
              break;
     case 0 : return c;

--- a/libhashkit/jenkins.cc
+++ b/libhashkit/jenkins.cc
@@ -241,9 +241,9 @@ uint32_t hashkit_jenkins(const char *key, size_t length, void *)
     case 4 : a+=((uint32_t)k[3])<<24; /* fall-thru */
     case 3 : a+=((uint32_t)k[2])<<16; /* fall-thru */
     case 2 : a+=((uint32_t)k[1])<<8; /* fall-thru */
-    case 1 : a+=k[0]; /* fall-thru */
+    case 1 : a+=k[0];
              break;
-    case 0 : return c; /* fall-thru */
+    case 0 : return c;
     default : return c;
     }
 #ifndef WORDS_BIGENDIAN

--- a/libhashkit/jenkins.cc
+++ b/libhashkit/jenkins.cc
@@ -230,20 +230,20 @@ uint32_t hashkit_jenkins(const char *key, size_t length, void *)
     /*-------------------------------- last block: affect all 32 bits of (c) */
     switch(length)                   /* all the case statements fall through */
     {
-    case 12: c+=((uint32_t)k[11])<<24;
-    case 11: c+=((uint32_t)k[10])<<16;
-    case 10: c+=((uint32_t)k[9])<<8;
-    case 9 : c+=k[8];
-    case 8 : b+=((uint32_t)k[7])<<24;
-    case 7 : b+=((uint32_t)k[6])<<16;
-    case 6 : b+=((uint32_t)k[5])<<8;
-    case 5 : b+=k[4];
-    case 4 : a+=((uint32_t)k[3])<<24;
-    case 3 : a+=((uint32_t)k[2])<<16;
-    case 2 : a+=((uint32_t)k[1])<<8;
-    case 1 : a+=k[0];
+    case 12: c+=((uint32_t)k[11])<<24; /* fall-thru */
+    case 11: c+=((uint32_t)k[10])<<16; /* fall-thru */
+    case 10: c+=((uint32_t)k[9])<<8; /* fall-thru */
+    case 9 : c+=k[8]; /* fall-thru */
+    case 8 : b+=((uint32_t)k[7])<<24; /* fall-thru */
+    case 7 : b+=((uint32_t)k[6])<<16; /* fall-thru */
+    case 6 : b+=((uint32_t)k[5])<<8; /* fall-thru */
+    case 5 : b+=k[4]; /* fall-thru */
+    case 4 : a+=((uint32_t)k[3])<<24; /* fall-thru */
+    case 3 : a+=((uint32_t)k[2])<<16; /* fall-thru */
+    case 2 : a+=((uint32_t)k[1])<<8; /* fall-thru */
+    case 1 : a+=k[0]; /* fall-thru */
              break;
-    case 0 : return c;
+    case 0 : return c; /* fall-thru */
     default : return c;
     }
 #ifndef WORDS_BIGENDIAN

--- a/libhashkit/murmur3.cc
+++ b/libhashkit/murmur3.cc
@@ -112,10 +112,10 @@ void MurmurHash3_x86_32 ( const void * key, int len,
 
   switch(len & 3)
   {
-  case 3: k1 ^= tail[2] << 16;
-  case 2: k1 ^= tail[1] << 8;
+  case 3: k1 ^= tail[2] << 16; /* fall-thru */
+  case 2: k1 ^= tail[1] << 8; /* fall-thru */
   case 1: k1 ^= tail[0];
-          k1 *= c1; k1 = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
+          k1 *= c1; k1 = ROTL32(k1,15); k1 *= c2; h1 ^= k1; /* fall-thru */
   };
 
   //----------
@@ -191,28 +191,28 @@ void MurmurHash3_x86_128 ( const void * key, const int len,
 
   switch(len & 15)
   {
-  case 15: k4 ^= tail[14] << 16;
-  case 14: k4 ^= tail[13] << 8;
-  case 13: k4 ^= tail[12] << 0;
-           k4 *= c4; k4  = ROTL32(k4,18); k4 *= c1; h4 ^= k4;
+  case 15: k4 ^= tail[14] << 16; /* fall-thru */
+  case 14: k4 ^= tail[13] << 8; /* fall-thru */
+  case 13: k4 ^= tail[12] << 0; /* fall-thru */
+           k4 *= c4; k4  = ROTL32(k4,18); k4 *= c1; h4 ^= k4; /* fall-thru */
 
-  case 12: k3 ^= tail[11] << 24;
-  case 11: k3 ^= tail[10] << 16;
-  case 10: k3 ^= tail[ 9] << 8;
-  case  9: k3 ^= tail[ 8] << 0;
-           k3 *= c3; k3  = ROTL32(k3,17); k3 *= c4; h3 ^= k3;
+  case 12: k3 ^= tail[11] << 24; /* fall-thru */
+  case 11: k3 ^= tail[10] << 16; /* fall-thru */
+  case 10: k3 ^= tail[ 9] << 8; /* fall-thru */
+  case  9: k3 ^= tail[ 8] << 0; /* fall-thru */
+           k3 *= c3; k3  = ROTL32(k3,17); k3 *= c4; h3 ^= k3; /* fall-thru */
 
-  case  8: k2 ^= tail[ 7] << 24;
-  case  7: k2 ^= tail[ 6] << 16;
-  case  6: k2 ^= tail[ 5] << 8;
-  case  5: k2 ^= tail[ 4] << 0;
-           k2 *= c2; k2  = ROTL32(k2,16); k2 *= c3; h2 ^= k2;
+  case  8: k2 ^= tail[ 7] << 24; /* fall-thru */
+  case  7: k2 ^= tail[ 6] << 16; /* fall-thru */
+  case  6: k2 ^= tail[ 5] << 8; /* fall-thru */
+  case  5: k2 ^= tail[ 4] << 0; /* fall-thru */
+           k2 *= c2; k2  = ROTL32(k2,16); k2 *= c3; h2 ^= k2; /* fall-thru */
 
-  case  4: k1 ^= tail[ 3] << 24;
-  case  3: k1 ^= tail[ 2] << 16;
-  case  2: k1 ^= tail[ 1] << 8;
+  case  4: k1 ^= tail[ 3] << 24; /* fall-thru */
+  case  3: k1 ^= tail[ 2] << 16; /* fall-thru */
+  case  2: k1 ^= tail[ 1] << 8; /* fall-thru */
   case  1: k1 ^= tail[ 0] << 0;
-           k1 *= c1; k1  = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
+           k1 *= c1; k1  = ROTL32(k1,15); k1 *= c2; h1 ^= k1; /* fall-thru */
   };
 
   //----------
@@ -284,24 +284,24 @@ void MurmurHash3_x64_128 ( const void * key, const int len,
 
   switch(len & 15)
   {
-  case 15: k2 ^= (uint64_t)(tail[14]) << 48;
-  case 14: k2 ^= (uint64_t)(tail[13]) << 40;
-  case 13: k2 ^= (uint64_t)(tail[12]) << 32;
-  case 12: k2 ^= (uint64_t)(tail[11]) << 24;
-  case 11: k2 ^= (uint64_t)(tail[10]) << 16;
-  case 10: k2 ^= (uint64_t)(tail[ 9]) << 8;
+  case 15: k2 ^= (uint64_t)(tail[14]) << 48; /* fall-thru */
+  case 14: k2 ^= (uint64_t)(tail[13]) << 40; /* fall-thru */
+  case 13: k2 ^= (uint64_t)(tail[12]) << 32; /* fall-thru */
+  case 12: k2 ^= (uint64_t)(tail[11]) << 24; /* fall-thru */
+  case 11: k2 ^= (uint64_t)(tail[10]) << 16; /* fall-thru */
+  case 10: k2 ^= (uint64_t)(tail[ 9]) << 8; /* fall-thru */
   case  9: k2 ^= (uint64_t)(tail[ 8]) << 0;
-           k2 *= c2; k2  = ROTL64(k2,33); k2 *= c1; h2 ^= k2;
+           k2 *= c2; k2  = ROTL64(k2,33); k2 *= c1; h2 ^= k2; /* fall-thru */
 
-  case  8: k1 ^= (uint64_t)(tail[ 7]) << 56;
-  case  7: k1 ^= (uint64_t)(tail[ 6]) << 48;
-  case  6: k1 ^= (uint64_t)(tail[ 5]) << 40;
-  case  5: k1 ^= (uint64_t)(tail[ 4]) << 32;
-  case  4: k1 ^= (uint64_t)(tail[ 3]) << 24;
-  case  3: k1 ^= (uint64_t)(tail[ 2]) << 16;
-  case  2: k1 ^= (uint64_t)(tail[ 1]) << 8;
+  case  8: k1 ^= (uint64_t)(tail[ 7]) << 56; /* fall-thru */
+  case  7: k1 ^= (uint64_t)(tail[ 6]) << 48; /* fall-thru */
+  case  6: k1 ^= (uint64_t)(tail[ 5]) << 40; /* fall-thru */
+  case  5: k1 ^= (uint64_t)(tail[ 4]) << 32; /* fall-thru */
+  case  4: k1 ^= (uint64_t)(tail[ 3]) << 24; /* fall-thru */
+  case  3: k1 ^= (uint64_t)(tail[ 2]) << 16; /* fall-thru */
+  case  2: k1 ^= (uint64_t)(tail[ 1]) << 8; /* fall-thru */
   case  1: k1 ^= (uint64_t)(tail[ 0]) << 0;
-           k1 *= c1; k1  = ROTL64(k1,31); k1 *= c2; h1 ^= k1;
+           k1 *= c1; k1  = ROTL64(k1,31); k1 *= c2; h1 ^= k1; /* fall-thru */
   };
 
   //----------

--- a/libhashkit/murmur3.cc
+++ b/libhashkit/murmur3.cc
@@ -112,10 +112,10 @@ void MurmurHash3_x86_32 ( const void * key, int len,
 
   switch(len & 3)
   {
-  case 3: k1 ^= tail[2] << 16; /* fall-thru */
-  case 2: k1 ^= tail[1] << 8; /* fall-thru */
+  case 3: k1 ^= tail[2] << 16; /* fall through */
+  case 2: k1 ^= tail[1] << 8; /* fall through */
   case 1: k1 ^= tail[0];
-          k1 *= c1; k1 = ROTL32(k1,15); k1 *= c2; h1 ^= k1; /* fall-thru */
+          k1 *= c1; k1 = ROTL32(k1,15); k1 *= c2; h1 ^= k1; /* fall through */
   };
 
   //----------
@@ -191,28 +191,28 @@ void MurmurHash3_x86_128 ( const void * key, const int len,
 
   switch(len & 15)
   {
-  case 15: k4 ^= tail[14] << 16; /* fall-thru */
-  case 14: k4 ^= tail[13] << 8; /* fall-thru */
-  case 13: k4 ^= tail[12] << 0; /* fall-thru */
-           k4 *= c4; k4  = ROTL32(k4,18); k4 *= c1; h4 ^= k4; /* fall-thru */
+  case 15: k4 ^= tail[14] << 16; /* fall through */
+  case 14: k4 ^= tail[13] << 8; /* fall through */
+  case 13: k4 ^= tail[12] << 0; /* fall through */
+           k4 *= c4; k4  = ROTL32(k4,18); k4 *= c1; h4 ^= k4; /* fall through */
 
-  case 12: k3 ^= tail[11] << 24; /* fall-thru */
-  case 11: k3 ^= tail[10] << 16; /* fall-thru */
-  case 10: k3 ^= tail[ 9] << 8; /* fall-thru */
-  case  9: k3 ^= tail[ 8] << 0; /* fall-thru */
-           k3 *= c3; k3  = ROTL32(k3,17); k3 *= c4; h3 ^= k3; /* fall-thru */
+  case 12: k3 ^= tail[11] << 24; /* fall through */
+  case 11: k3 ^= tail[10] << 16; /* fall through */
+  case 10: k3 ^= tail[ 9] << 8; /* fall through */
+  case  9: k3 ^= tail[ 8] << 0; /* fall through */
+           k3 *= c3; k3  = ROTL32(k3,17); k3 *= c4; h3 ^= k3; /* fall through */
 
-  case  8: k2 ^= tail[ 7] << 24; /* fall-thru */
-  case  7: k2 ^= tail[ 6] << 16; /* fall-thru */
-  case  6: k2 ^= tail[ 5] << 8; /* fall-thru */
-  case  5: k2 ^= tail[ 4] << 0; /* fall-thru */
-           k2 *= c2; k2  = ROTL32(k2,16); k2 *= c3; h2 ^= k2; /* fall-thru */
+  case  8: k2 ^= tail[ 7] << 24; /* fall through */
+  case  7: k2 ^= tail[ 6] << 16; /* fall through */
+  case  6: k2 ^= tail[ 5] << 8; /* fall through */
+  case  5: k2 ^= tail[ 4] << 0; /* fall through */
+           k2 *= c2; k2  = ROTL32(k2,16); k2 *= c3; h2 ^= k2; /* fall through */
 
-  case  4: k1 ^= tail[ 3] << 24; /* fall-thru */
-  case  3: k1 ^= tail[ 2] << 16; /* fall-thru */
-  case  2: k1 ^= tail[ 1] << 8; /* fall-thru */
+  case  4: k1 ^= tail[ 3] << 24; /* fall through */
+  case  3: k1 ^= tail[ 2] << 16; /* fall through */
+  case  2: k1 ^= tail[ 1] << 8; /* fall through */
   case  1: k1 ^= tail[ 0] << 0;
-           k1 *= c1; k1  = ROTL32(k1,15); k1 *= c2; h1 ^= k1; /* fall-thru */
+           k1 *= c1; k1  = ROTL32(k1,15); k1 *= c2; h1 ^= k1; /* fall through */
   };
 
   //----------
@@ -284,24 +284,24 @@ void MurmurHash3_x64_128 ( const void * key, const int len,
 
   switch(len & 15)
   {
-  case 15: k2 ^= (uint64_t)(tail[14]) << 48; /* fall-thru */
-  case 14: k2 ^= (uint64_t)(tail[13]) << 40; /* fall-thru */
-  case 13: k2 ^= (uint64_t)(tail[12]) << 32; /* fall-thru */
-  case 12: k2 ^= (uint64_t)(tail[11]) << 24; /* fall-thru */
-  case 11: k2 ^= (uint64_t)(tail[10]) << 16; /* fall-thru */
-  case 10: k2 ^= (uint64_t)(tail[ 9]) << 8; /* fall-thru */
+  case 15: k2 ^= (uint64_t)(tail[14]) << 48; /* fall through */
+  case 14: k2 ^= (uint64_t)(tail[13]) << 40; /* fall through */
+  case 13: k2 ^= (uint64_t)(tail[12]) << 32; /* fall through */
+  case 12: k2 ^= (uint64_t)(tail[11]) << 24; /* fall through */
+  case 11: k2 ^= (uint64_t)(tail[10]) << 16; /* fall through */
+  case 10: k2 ^= (uint64_t)(tail[ 9]) << 8; /* fall through */
   case  9: k2 ^= (uint64_t)(tail[ 8]) << 0;
-           k2 *= c2; k2  = ROTL64(k2,33); k2 *= c1; h2 ^= k2; /* fall-thru */
+           k2 *= c2; k2  = ROTL64(k2,33); k2 *= c1; h2 ^= k2; /* fall through */
 
-  case  8: k1 ^= (uint64_t)(tail[ 7]) << 56; /* fall-thru */
-  case  7: k1 ^= (uint64_t)(tail[ 6]) << 48; /* fall-thru */
-  case  6: k1 ^= (uint64_t)(tail[ 5]) << 40; /* fall-thru */
-  case  5: k1 ^= (uint64_t)(tail[ 4]) << 32; /* fall-thru */
-  case  4: k1 ^= (uint64_t)(tail[ 3]) << 24; /* fall-thru */
-  case  3: k1 ^= (uint64_t)(tail[ 2]) << 16; /* fall-thru */
-  case  2: k1 ^= (uint64_t)(tail[ 1]) << 8; /* fall-thru */
+  case  8: k1 ^= (uint64_t)(tail[ 7]) << 56; /* fall through */
+  case  7: k1 ^= (uint64_t)(tail[ 6]) << 48; /* fall through */
+  case  6: k1 ^= (uint64_t)(tail[ 5]) << 40; /* fall through */
+  case  5: k1 ^= (uint64_t)(tail[ 4]) << 32; /* fall through */
+  case  4: k1 ^= (uint64_t)(tail[ 3]) << 24; /* fall through */
+  case  3: k1 ^= (uint64_t)(tail[ 2]) << 16; /* fall through */
+  case  2: k1 ^= (uint64_t)(tail[ 1]) << 8; /* fall through */
   case  1: k1 ^= (uint64_t)(tail[ 0]) << 0;
-           k1 *= c1; k1  = ROTL64(k1,31); k1 *= c2; h1 ^= k1; /* fall-thru */
+           k1 *= c1; k1  = ROTL64(k1,31); k1 *= c2; h1 ^= k1; /* fall through */
   };
 
   //----------

--- a/libtest/client.cc
+++ b/libtest/client.cc
@@ -373,6 +373,7 @@ bool SimpleClient::message(const char* ptr, const size_t len)
                 write_size= SOCKET_ERROR;
                 break;
               }
+              /* fall-thru */
 
             case SSL_ERROR_SSL:
             default:
@@ -494,6 +495,7 @@ bool SimpleClient::response(libtest::vchar_t& response_)
                 read_size= SOCKET_ERROR;
                 break;
               }
+              /* fall-thru */
 
             case SSL_ERROR_SSL:
             default:
@@ -589,6 +591,7 @@ bool SimpleClient::response(std::string& response_)
               {
                 break;
               }
+              /* fall-thru */
 
             case SSL_ERROR_SSL:
             default:

--- a/util/instance.cc
+++ b/util/instance.cc
@@ -314,6 +314,7 @@ bool Instance::run()
                     break;
                   }
                 }
+              /* fall-thru */
 
               case SSL_ERROR_SSL:
               default:
@@ -397,6 +398,7 @@ bool Instance::run()
                       break;
                     }
                   }
+                /* fall-thru */
 
                 case SSL_ERROR_SSL:
                 default:

--- a/util/instance.cc
+++ b/util/instance.cc
@@ -208,7 +208,7 @@ bool Instance::run()
         return false;
       }
       _addrinfo_next= _addrinfo_next->ai_next;
-
+      /* fall-thru */
 
     case CONNECT:
       close_socket();


### PR DESCRIPTION
As mentioned in PR #193 there is several fall through warnings that needs to be addressed and fixed