### PR TITLE
Support for key prefix in redis and libmemcached queue plugins

### DIFF
--- a/libgearman-server/plugins/queue/redis/queue.h
+++ b/libgearman-server/plugins/queue/redis/queue.h
@@ -71,6 +71,7 @@ class Hiredis : public Queue {
     std::string server;
     std::string service;
     std::string password;
+    std::string prefix;
 
     Hiredis();
     ~Hiredis();

--- a/tests/memcached_test.cc
+++ b/tests/memcached_test.cc
@@ -215,6 +215,30 @@ static test_return_t collection_init(void *object)
   return TEST_SUCCESS;
 }
 
+static test_return_t collection_init_with_prefix(void *object)
+{
+  Context *test= (Context *)object;
+  assert(test);
+
+  memcached_port= libtest::get_free_port();
+  ASSERT_TRUE(server_startup(test->_servers, "memcached", memcached_port, NULL));
+
+  char memcached_server_string[1024];
+  int length= snprintf(memcached_server_string,
+                       sizeof(memcached_server_string),
+                       "--libmemcached-servers=localhost:%d --libmemcached-prefix=prefix_",
+                       int(memcached_port));
+  ASSERT_TRUE(size_t(length) < sizeof(memcached_server_string));
+  const char *argv[]= {
+    memcached_server_string,
+    "--queue-type=libmemcached",
+    0 };
+
+  ASSERT_TRUE(test->initialize(argv));
+
+  return TEST_SUCCESS;
+}
+
 static test_return_t collection_cleanup(void *object)
 {
   Context *test= (Context *)object;
@@ -270,6 +294,7 @@ test_st queue_restart_TESTS[] ={
 collection_st collection[] ={
   {"gearmand options", 0, 0, gearmand_basic_option_tests},
   {"memcached queue", collection_init, collection_cleanup, tests},
+  {"memcached queue with prefix", collection_init_with_prefix, collection_cleanup, tests},
   {"queue restart", 0, collection_cleanup, queue_restart_TESTS},
   {0, 0, 0, 0}
 };

--- a/tests/redis.cc
+++ b/tests/redis.cc
@@ -81,6 +81,19 @@ static test_return_t collection_init(void *object)
   return TEST_SUCCESS;
 }
 
+static test_return_t collection_init_with_prefix(void *object)
+{
+  SKIP_IF(true);
+  Context *test= (Context *)object;
+  assert(test);
+
+  const char *argv[]= { "--queue-type=redis", "--redis-prefix=_prefix_", 0 };
+
+  test->initialize(argv);
+
+  return TEST_SUCCESS;
+}
+
 static test_return_t collection_cleanup(void *object)
 {
   Context *test= (Context *)object;
@@ -142,6 +155,7 @@ test_st regressions[] ={
 collection_st collection[] ={
   {"gearmand redis options", 0, 0, gearmand_basic_option_tests},
   {"redis queue", collection_init, collection_cleanup, tests},
+  {"redis queue with prefix", collection_init_with_prefix, collection_cleanup, tests},
   {"regressions", collection_init, collection_cleanup, regressions},
   {0, 0, 0, 0}
 };


### PR DESCRIPTION
Hey folks! I implemented a `--libmemcached-prefix` flag for some experiments we're doing at work. It allows you overrides the default `gear_` prefix used in the memcached key so that more than one gearmand instance can use the same memcached without replaying each others jobs. I also saw https://github.com/gearman/gearmand/issues/60 for the same thing in the redis plugin and thought I'd take a stab at that too since the principle is the same.

I know using the persistence plugins isn't recommended (as @SpamapS noted in the issue above), but thought I'd might as well see if anyone was interested in a patch. If omitted, the new parameters default to the current `gear_` (libmemcached) and `_gear_` (redis) prefixes.