### PR TITLE
memset bug fixing in current_epoch_handler

### DIFF
--- a/libgearman-server/timer.cc
+++ b/libgearman-server/timer.cc
@@ -59,11 +59,10 @@ static int wakeup_fd[2];
 static __attribute__((noreturn)) void* current_epoch_handler(void*)
 {
   gearmand_debug("staring up Epoch thread");
-
   pollfd fds[2];
   while (true)
   {
-    memset(fds, 0, sizeof(pollfd));
+    memset(fds, 0, sizeof(fds));
     fds[0].fd= -1; //STDIN_FILENO;
     fds[0].events= POLLIN;
     fds[0].revents= 0;

--- a/libgearman-server/timer.cc
+++ b/libgearman-server/timer.cc
@@ -58,7 +58,7 @@ static int wakeup_fd[2];
 
 static __attribute__((noreturn)) void* current_epoch_handler(void*)
 {
-  gearmand_debug("staring up Epoch thread");
+  gearmand_debug("starting up Epoch thread");
   pollfd fds[2];
   while (true)
   {


### PR DESCRIPTION
cherry picked from #114 to solve:
```
Viva64-EM
full
66
/nfs/home/dmka/src/gearmand/libgearman-server/timer.cc
error
V512
A call of the 'memset' function will lead to underflow of the buffer 'fds'.
false
1
  {
    memset(fds, 0, sizeof(pollfd));
    fds[0].fd= -1; //STDIN_FILENO;
------------
```
https://github.com/p-alik/gearmand/issues/8