### PR TITLE
Issue 165: Fix unknown type name 'my_bool' when compiling with MySQL 8+

### DIFF
--- a/libgearman-server/plugins/queue/mysql/queue.cc
+++ b/libgearman-server/plugins/queue/mysql/queue.cc
@@ -47,6 +47,11 @@
 #include <libgearman-server/plugins/queue/base.h>
 
 #include <mysql.h>
+#if !defined(MARIADB_BASE_VERSION) && !defined(MARIADB_VERSION_ID) && \
+  MYSQL_VERSION_ID >= 80001 && MYSQL_VERSION_ID != 80002
+typedef bool my_bool;
+#endif
+
 #include <errmsg.h>
 #include <cerrno>
 


### PR DESCRIPTION
MySQL 8.0.1 and 8.0.3+ do not define a 'my_bool' type.

Refer to issue #165 and https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-1.html.