### PR TITLE
Fix gcc 7/8 compilation errors from -Wimplicit-fallthrough with SSL support enabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ before_script:
 
 script:
   - ./bootstrap.sh -a
-  - ./configure
+  - ./configure --enable-ssl
   - make
   - make test
 

--- a/libgearman-server/io.cc
+++ b/libgearman-server/io.cc
@@ -113,6 +113,9 @@ const char* gearmand_io_st::port() const
   return "-";
 }
 
+#if __GNUC__ >= 7
+  #pragma GCC diagnostic warning "-Wimplicit-fallthrough"
+#endif
 static size_t _connection_read(gearman_server_con_st *con, void *data, size_t data_size, gearmand_error_t &ret)
 {
   ssize_t read_size;

--- a/libtest/client.cc
+++ b/libtest/client.cc
@@ -329,6 +329,9 @@ bool SimpleClient::is_valid()
   return true;
 }
 
+#if __GNUC__ >= 7
+  #pragma GCC diagnostic warning "-Wimplicit-fallthrough"
+#endif
 bool SimpleClient::message(const char* ptr, const size_t len)
 {
   if (is_valid())
@@ -442,6 +445,9 @@ bool SimpleClient::send_message(const std::string& message_, std::string& respon
   return false;
 }
 
+#if __GNUC__ >= 7
+  #pragma GCC diagnostic warning "-Wimplicit-fallthrough"
+#endif
 bool SimpleClient::response(libtest::vchar_t& response_)
 {
   response_.clear();


### PR DESCRIPTION
* Change Travis CI builds to configure with '--enable-ssl' for more complete code coverage.
* Add GCC pragmas to avoid compilation errors with -Wimplicit-fallthrough on gcc 7/8.