### PR TITLE
OpenSSL 1.1 deprecates function 'TLSv1_2_client_method'

### DIFF
--- a/libgearman/universal.cc
+++ b/libgearman/universal.cc
@@ -473,7 +473,11 @@ bool gearman_universal_st::init_ssl()
     SSL_load_error_strings();
     SSL_library_init();
 
-    if ((_ctx_ssl= SSL_CTX_new(TLSv1_client_method())) == NULL)
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L)
+    if ((_ctx_ssl= SSL_CTX_new(TLSv1_2_client_method())) == NULL)
+#else
+    if ((_ctx_ssl= SSL_CTX_new(TLS_client_method())) == NULL)
+#endif
     {
       gearman_universal_set_error(*this, GEARMAN_INVALID_ARGUMENT, GEARMAN_AT, "CyaTLSv1_client_method() failed");
       return false;

--- a/util/instance.cc
+++ b/util/instance.cc
@@ -125,7 +125,11 @@ bool Instance::init_ssl()
   SSL_load_error_strings();
   SSL_library_init();
 
-  if ((_ctx_ssl= SSL_CTX_new(TLSv1_client_method())) == NULL)
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L)
+  if ((_ctx_ssl= SSL_CTX_new(TLSv1_2_client_method())) == NULL)
+#else
+  if ((_ctx_ssl= SSL_CTX_new(TLS_client_method())) == NULL)
+#endif
   {
     _last_error= "SSL_CTX_new error";
     return false;


### PR DESCRIPTION
As OpenSSL 1.1 deprecates TLSv1.2 (https://wiki.openssl.org/index.php/TLS1.3) and SSL2. This Pull Request converts it to general TLS client method (Which in OpenSSL should be version 1.3). It should negotiate correct TLS level. There is #ifdef to make sure that also below OpenSSL 1.1 it will work as before.