### PR TITLE
Add explicit '${CC} --version' to Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,6 +90,7 @@ before_script:
   - export -f travis_fold
 
 script:
+  - ${CC} --version
   - ./bootstrap.sh -a
   - ./configure --enable-ssl
   - make


### PR DESCRIPTION
This should make it more obvious which version of the compiler each build is using. This syntax works with both clang and gcc.