### PR TITLE
Fix manpage/docs for gearmand --verbose level

### DIFF
--- a/docs/source/gearmand.rst
+++ b/docs/source/gearmand.rst
@@ -73,7 +73,7 @@ SYNOPSIS
 
 .. option:: -v [ --verbose ] arg (=v)
 
-   Increase verbosity level by one.
+   Set verbosity level. Defaults to ERROR. Accepts FATAL, ALERT, CRITICAL, ERROR, WARNING, NOTICE, INFO, and DEBUG.
 
 .. option:: -V [ --version ]
 


### PR DESCRIPTION
This doesn't work as an increment. It only works if you pass in the
right level. Whether that is right or not is less important than
matching the docs to how the program actually works right now.

Closes: https://bugs.launchpad.net/ubuntu/+source/gearmand/+bug/1357523