### PR TITLE
Fix strncpy() warning in libgearman/run.cc when compiling with gcc 8

### DIFF
--- a/libgearman/run.cc
+++ b/libgearman/run.cc
@@ -271,6 +271,7 @@ gearman_return_t _client_run_task(Task *task)
       {
         task->error_code(GEARMAN_SUCCESS);
         strncpy(task->unique, task->recv->arg[0], GEARMAN_MAX_UNIQUE_SIZE);
+        task->unique[GEARMAN_MAX_UNIQUE_SIZE -1]= '\0';
         if (atoi(static_cast<char *>(task->recv->arg[1])) == 0)
         {
           task->options.is_known= false;


### PR DESCRIPTION
This splits off one of the changes from PR #229 into a separate PR.

It fixes the following warning message when compiled with gcc 8.2.0+:
```
libgearman/run.cc:272:16: warning: ‘char* strncpy(char*, const char*, size_t)’
         specified bound 64 equals destination size [-Wstringop-truncation]
         strncpy(task->unique, task->recv->arg[0], GEARMAN_MAX_UNIQUE_SIZE);
```

More information:
https://developers.redhat.com/blog/2018/05/24/detecting-string-truncation-with-gcc-8/

Relevant section:

> *Mitigating strncpy Truncation*
>
> Since it is not possible to avoid truncation by strncpy, when using other functions is not feasible, it is necessary to make sure the result of strncpy is properly NUL-terminated and the NUL must be inserted explicitly, after strncpy has returned:
```C
    char pathname[256];
    strncpy (pathname, dirname, sizeof pathname);
    pathname[sizeof pathname - 1] = '\0';
```
> GCC tries to detect these uses and avoid issuing the warning when it can determine that the NUL is inserted before the array is used by a string-handling function. However, the simple approach outlined above suffers from the same problem as ignoring snprintf truncation and so, to be safe, the truncation should be detected and handled as discussed above. GCC 8 doesn’t detect the missing handling in this case but future versions might.