### PR TITLE
Fix strncpy() warning in libtest/socket.cc when compiling with gcc 8

### DIFF
--- a/libtest/socket.cc
+++ b/libtest/socket.cc
@@ -55,7 +55,8 @@ void set_default_socket(const char *socket)
 {
   if (socket)
   {
-    strncpy(global_socket, socket, strlen(socket));
+    strncpy(global_socket, socket, sizeof(global_socket));
+    global_socket[sizeof(global_socket) -1]= '\0';
   }
 }
 


### PR DESCRIPTION
This splits off one of the changes from PR #229 into a separate PR.

It fixes the following warning message when compiled with gcc 8.2.0+:
```
libtest/socket.cc:58:12: warning: ‘char* strncpy(char*, const char*, size_t)’
         output truncated before terminating nul copying as many bytes from a
         string as its length [-Wstringop-truncation]
         strncpy(global_socket, socket, strlen(socket));
```

More information:
https://developers.redhat.com/blog/2018/05/24/detecting-string-truncation-with-gcc-8/

Relevant section:

> *Mitigating strncpy Truncation*
>
> Since it is not possible to avoid truncation by strncpy, when using other functions is not feasible, it is necessary to make sure the result of strncpy is properly NUL-terminated and the NUL must be inserted explicitly, after strncpy has returned:
```C
    char pathname[256];
    strncpy (pathname, dirname, sizeof pathname);
    pathname[sizeof pathname - 1] = '\0';
```
> GCC tries to detect these uses and avoid issuing the warning when it can determine that the NUL is inserted before the array is used by a string-handling function. However, the simple approach outlined above suffers from the same problem as ignoring snprintf truncation and so, to be safe, the truncation should be detected and handled as discussed above. GCC 8 doesn’t detect the missing handling in this case but future versions might.