### PR TITLE
Update Travis CI to Ubuntu Xenial and add Clang 7 and 8 builds (Issue #238)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 os:
   - linux
 language: cpp
-dist: trusty
+dist: xenial
 sudo: required
 
 matrix:
@@ -10,7 +10,7 @@ matrix:
       addons:
         apt:
           sources:
-            - llvm-toolchain-trusty-4.0
+            - llvm-toolchain-xenial-4.0
           packages:
             - clang-4.0
         artifacts: true
@@ -20,13 +20,44 @@ matrix:
       addons:
         apt:
           sources:
-            - llvm-toolchain-trusty-5.0
+            - llvm-toolchain-xenial-5.0
           packages:
             - clang-5.0
         artifacts: true
       env:
         - MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0"
+    - compiler: clang
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-xenial-6.0
+          packages:
+            - clang-6.0
+        artifacts: true
+      env:
+        - MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0"
+    - compiler: clang
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-xenial-7
+          packages:
+            - clang-7
+        artifacts: true
+      env:
+        - MATRIX_EVAL="CC=clang-7 && CXX=clang++-7"
+    - compiler: clang
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-xenial-8
+          packages:
+            - clang-8
+        artifacts: true
+      env:
+        - MATRIX_EVAL="CC=clang-8 && CXX=clang++-8"
     - compiler: gcc
+      dist: trusty
       addons:
         apt:
           sources:


### PR DESCRIPTION
This PR addresses issue #238. It also adds builds using clang 7 and clang 8.

https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment says:

> Since Ubuntu 14.04 reaches End of Life on April 30th, 2019, we’ll be gradually setting the default distribution for builds to Linux, Ubuntu Xenial 16.04.

