### PR TITLE
fix build on gcc 4.8 (fixes #246)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,18 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
+            - gcc-4.8
+            - g++-4.8
+        artifacts: true
+      env:
+        - MATRIX_EVAL="CC=gcc-4.8 && CXX=g++-4.8"
+    - compiler: gcc
+      dist: trusty
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
             - gcc-4.9
             - g++-4.9
         artifacts: true

--- a/libgearman-server/gearmand_thread.cc
+++ b/libgearman-server/gearmand_thread.cc
@@ -167,7 +167,7 @@ gearmand_thread_st::gearmand_thread_st(gearmand_st& gearmand_):
   dcon_add_count{0},
   free_dcon_count{0},
   wakeup_fd{},
-  _gearmand{gearmand_},
+  _gearmand(gearmand_),
   next{nullptr},
   prev{nullptr},
   base{nullptr},

--- a/libgearman/server_options.cc
+++ b/libgearman/server_options.cc
@@ -66,7 +66,7 @@ gearman_server_options_st::gearman_server_options_st(gearman_universal_st &unive
   _option{option_arg_size},
   next{nullptr},
   prev{nullptr},
-  universal{universal_}
+  universal(universal_)
 {
   _option.append(option_arg, option_arg_size);
   if (universal.server_options_list)


### PR DESCRIPTION
build fails with:

```
libgearman/server_options.cc: In constructor 'gearman_server_options_st::gearman_server_options_st(gearman_universal_st&, const char*, size_t)':
libgearman/server_options.cc:69:23: error: invalid initialization of non-const reference of type 'gearman_universal_st&' from an rvalue of type '<brace-enclosed initializer list>'
   universal{universal_}
```

Signed-off-by: Sven Nierlein <sven@nierlein.de>