### PR TITLE
Issue #246: Support gcc 4.8.5/CentOS 7.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,18 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
+            - gcc-4.8
+            - g++-4.8
+        artifacts: true
+      env:
+        - MATRIX_EVAL="CC=gcc-4.8 && CXX=g++-4.8"
+    - compiler: gcc
+      dist: trusty
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
             - gcc-4.9
             - g++-4.9
         artifacts: true

--- a/libgearman-server/gearmand_thread.cc
+++ b/libgearman-server/gearmand_thread.cc
@@ -167,7 +167,11 @@ gearmand_thread_st::gearmand_thread_st(gearmand_st& gearmand_):
   dcon_add_count{0},
   free_dcon_count{0},
   wakeup_fd{},
+#if __GNUC__ == 4 && __GNUC_MINOR__ < 9
+  _gearmand(gearmand_),
+#else
   _gearmand{gearmand_},
+#endif
   next{nullptr},
   prev{nullptr},
   base{nullptr},

--- a/libgearman/server_options.cc
+++ b/libgearman/server_options.cc
@@ -66,7 +66,11 @@ gearman_server_options_st::gearman_server_options_st(gearman_universal_st &unive
   _option{option_arg_size},
   next{nullptr},
   prev{nullptr},
+#if __GNUC__ == 4 && __GNUC_MINOR__ < 9
+  universal(universal_)
+#else
   universal{universal_}
+#endif
 {
   _option.append(option_arg, option_arg_size);
   if (universal.server_options_list)


### PR DESCRIPTION
Alternative patch to PR#247.

This one retains the new initializer brace syntax for newer versions of gcc. Primarily for compatibility with RHEL/CentOS 7.x, it uses a preprocessor conditional to work around the lack of full brace initializer syntax in gcc 4.8.5.

This PR also adds gcc/g++ 4.8.5 builds to Travis CI.