### PR TITLE
Add support for Scientific Linux (free alternative to RHEL/CentOS)

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -338,6 +338,10 @@ determine_target_platform ()
     local fedora_version
     fedora_version="$(awk ' { print $3 } ' < /etc/fedora-release)"
     set_VENDOR 'redhat' 'fedora' "$fedora_version"
+  elif [[ -f '/etc/sl-release' ]]; then
+    local sl_version
+    sl_version="$(awk ' { print $4 } ' < /etc/sl-release)"
+    set_VENDOR 'centos' 'rhel' "$sl_version"
   elif [[ -f '/etc/centos-release' ]]; then
     local centos_version
     centos_version="$(awk ' { print $7 } ' < /etc/centos-release)"


### PR DESCRIPTION
Scientific Linux (SL) is a Linux distribution produced by Fermilab, CERN, DESY, and ETH Zurich and utilized by various other academic and US government institutions. It is a free and open-source alternative distribution that is based on RHEL (and also CentOS). Its packages, kernels, and executables are identical to RHEL/CentOS.

The only problem is `/etc/redhat-release` is different and the `awk` command in `bootstrap.sh` uses the wrong field when parsing the version number with `awk`. This PR fixes that.