### PR TITLE
Address Issue #196 by fixing the conversion of milliseconds to timeval

### DIFF
--- a/PROTOCOL
+++ b/PROTOCOL
@@ -332,7 +332,7 @@ CAN_DO_TIMEOUT
 
      Arguments:
      - NULL byte terminated Function name.
-     - Timeout value.
+     - Timeout value (in milliseconds).
 
 CANT_DO
 

--- a/libgearman-server/connection.cc
+++ b/libgearman-server/connection.cc
@@ -717,7 +717,9 @@ gearmand_error_t gearman_server_con_add_job_timeout(gearman_server_con_st *con, 
           and only set this one if it is longer than that one. */
 
         struct timeval timeout_tv = { 0 , 0 };
-        timeout_tv.tv_sec= worker->timeout;
+        time_t milliseconds= worker->timeout;
+        timeout_tv.tv_sec= milliseconds / 1000;
+        timeout_tv.tv_usec= (long)((milliseconds % 1000) * 1000);
         timeout_add(con->timeout_event, &timeout_tv);
       }
       else if (con->timeout_event) // Delete the timer if it exists


### PR DESCRIPTION
This addresses issue #196 by fixing the conversion of the timeout in milliseconds to the `struct timeval` in `libgearman-server/connection.cc`. This seems the simplest way to fix this rather egregious bug. I still think seconds is the more intuitive unit for a job timeout, but that would require more widespread changes and I haven't received much feedback preferring that as a solution.

Any objection to my modification of the PROTOCOL file to firmly document that the timeout should be specified in milliseconds?