### PR TITLE
Fix misspellings in ChangeLog

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -22,8 +22,8 @@ be able to handle multiple servers.
 * Added gearman_task_is_finished()
 * Improved SSL support.
 * Exceptions are now supported.
-* gearmand excepts its root CA via the environmental variable GEARMAND_PORT. 
-* libgearman will now except GEARMAND_CA_CERTIFICATE, GEARMAN_CLIENT_PEM, and GEARMAN_CLIENT_KEY
+* gearmand accepts its root CA via the environmental variable GEARMAND_PORT. 
+* libgearman will now accept GEARMAND_CA_CERTIFICATE, GEARMAN_CLIENT_PEM, and GEARMAN_CLIENT_KEY.
 
 1.1.8 Thu Jun  6 18:47:01 EDT 2013
 * Postgres test case now passes.


### PR DESCRIPTION
Trivial change to ChangeLog to correct some spelling errors.