### PR TITLE
Issue #63: Add set_ssl API to libgearman for PHP extension and other potential uses

### DIFF
--- a/libgearman-1.0/client.h
+++ b/libgearman-1.0/client.h
@@ -172,6 +172,13 @@ GEARMAN_API
 void gearman_client_set_timeout(gearman_client_st *client, int timeout);
 
 /**
+ * See gearman_universal_set_ssl() for details.
+ */
+GEARMAN_API
+void gearman_client_set_ssl(gearman_client_st *client, bool ssl,
+    const char *ca_file, const char *certificate, const char *key_file);
+
+/**
  * Get the application context for a client.
  *
  * @param[in] client Structure previously initialized with

--- a/libgearman-1.0/worker.h
+++ b/libgearman-1.0/worker.h
@@ -180,6 +180,13 @@ GEARMAN_API
 void gearman_worker_set_timeout(gearman_worker_st *worker, int timeout);
 
 /**
+ * See gearman_universal_set_ssl() for details.
+ */
+GEARMAN_API
+void gearman_worker_set_ssl(gearman_worker_st *worker, bool ssl,
+    const char *ca_file, const char *certificate, const char *key_file);
+
+/**
  * Get the application context for a worker.
  *
  * @param[in] worker Structure previously initialized with

--- a/libgearman-server/io.cc
+++ b/libgearman-server/io.cc
@@ -162,10 +162,6 @@ static size_t _connection_read(gearman_server_con_st *con, void *data, size_t da
         case SSL_ERROR_SSL:
         default:
           { // All other errors
-            if (ERR_peek_last_error())
-            {
-              ssl_error = ERR_peek_last_error();
-            }
             char errorString[SSL_ERROR_SIZE]= { 0 };
             ERR_error_string_n(ssl_error, errorString, sizeof(errorString));
             ret= GEARMAND_LOST_CONNECTION;

--- a/libgearman-server/io.cc
+++ b/libgearman-server/io.cc
@@ -800,7 +800,7 @@ gearmand_error_t gearman_io_recv(gearman_server_con_st *con, bool recv_data)
       connection->recv_buffer_ptr= connection->recv_buffer;
 
       size_t recv_size= _connection_read(con, connection->recv_buffer + connection->recv_buffer_size,
-					 GEARMAND_RECV_BUFFER_SIZE - connection->recv_buffer_size, ret);
+                                         GEARMAND_RECV_BUFFER_SIZE - connection->recv_buffer_size, ret);
       if (gearmand_failed(ret))
       {
         // GEARMAND_LOST_CONNECTION is not worth a warning, clients/workers just

--- a/libgearman-server/plugins/protocol/gear/protocol.cc
+++ b/libgearman-server/plugins/protocol/gear/protocol.cc
@@ -395,10 +395,6 @@ static gearmand_error_t _gear_con_add(gearman_server_con_st *connection)
         default:
           {
             char ssl_error_buffer[SSL_ERROR_SIZE]= { 0 };
-            if (ERR_peek_last_error())
-            {
-              ssl_error = ERR_peek_last_error();
-            }
             ERR_error_string_n(ssl_error, ssl_error_buffer, sizeof(ssl_error_buffer));
             return gearmand_log_gerror(GEARMAN_DEFAULT_LOG_PARAM, GEARMAND_LOST_CONNECTION, "%s(%d)",
                                        ssl_error_buffer, ssl_error);

--- a/libgearman-server/plugins/protocol/gear/protocol.cc
+++ b/libgearman-server/plugins/protocol/gear/protocol.cc
@@ -374,8 +374,8 @@ static gearmand_error_t _gear_con_add(gearman_server_con_st *connection)
     int accept_error;
     while ((accept_error= SSL_accept(connection->_ssl)) != SSL_SUCCESS)
     {
-      int wolfssl_error;
-      switch (wolfssl_error= SSL_get_error(connection->_ssl, accept_error))
+      int ssl_error;
+      switch (ssl_error= SSL_get_error(connection->_ssl, accept_error))
       {
         case SSL_ERROR_NONE:
           break;
@@ -393,10 +393,16 @@ static gearmand_error_t _gear_con_add(gearman_server_con_st *connection)
         case SSL_ERROR_SSL:
         case SSL_ERROR_ZERO_RETURN:
         default:
-          char wolfssl_error_buffer[SSL_ERROR_SIZE]= { 0 };
-          ERR_error_string_n(wolfssl_error, wolfssl_error_buffer, sizeof(wolfssl_error_buffer));
-          return gearmand_log_gerror(GEARMAN_DEFAULT_LOG_PARAM, GEARMAND_LOST_CONNECTION, "%s(%d)", 
-                                     wolfssl_error_buffer, wolfssl_error);
+          {
+            char ssl_error_buffer[SSL_ERROR_SIZE]= { 0 };
+            if (ERR_peek_last_error())
+            {
+              ssl_error = ERR_peek_last_error();
+            }
+            ERR_error_string_n(ssl_error, ssl_error_buffer, sizeof(ssl_error_buffer));
+            return gearmand_log_gerror(GEARMAN_DEFAULT_LOG_PARAM, GEARMAND_LOST_CONNECTION, "%s(%d)",
+                                       ssl_error_buffer, ssl_error);
+          }
       }
     }
     gearmand_log_debug(GEARMAN_DEFAULT_LOG_PARAM, "GearSSL connection made: %s:%s", connection->host(), connection->port());
@@ -511,6 +517,12 @@ gearmand_error_t Gear::start(gearmand_st *gearmand)
       gearmand_log_fatal(GEARMAN_DEFAULT_LOG_PARAM, "SSL_CTX_use_PrivateKey_file() cannot obtain certificate %s", _ssl_key.c_str());
     }
     gearmand_log_info(GEARMAN_DEFAULT_LOG_PARAM, "Loading certificate key : %s", _ssl_key.c_str());
+
+    if (SSL_CTX_check_private_key(gearmand->ctx_ssl()) != SSL_SUCCESS)
+    {
+      gearmand_log_fatal(GEARMAN_DEFAULT_LOG_PARAM, "SSL_CTX_check_private_key() cannot check certificate %s", _ssl_key.c_str());
+    }
+    gearmand_log_info(GEARMAN_DEFAULT_LOG_PARAM, "Checking certificate key : %s", _ssl_key.c_str());
 
     assert(gearmand->ctx_ssl());
   }

--- a/libgearman/client.cc
+++ b/libgearman/client.cc
@@ -546,6 +546,15 @@ void gearman_client_set_timeout(gearman_client_st *client_shell, int timeout)
   }
 }
 
+void gearman_client_set_ssl(gearman_client_st *client_shell, bool ssl,
+    const char *ca_file, const char *certificate, const char *key_file)
+{
+  if (client_shell && client_shell->impl())
+  {
+    gearman_universal_set_ssl(client_shell->impl()->universal, ssl, ca_file, certificate, key_file);
+  }
+}
+
 void *gearman_client_context(const gearman_client_st *client_shell)
 {
   if (client_shell and client_shell->impl())

--- a/libgearman/connection.cc
+++ b/libgearman/connection.cc
@@ -874,10 +874,6 @@ gearman_return_t gearman_connection_st::flush()
             case SSL_ERROR_SSL:
             default:
               {
-                if (ERR_peek_last_error())
-                {
-                  ssl_error = ERR_peek_last_error();
-                }
                 char errorString[SSL_ERROR_SIZE]= { 0 };
                 ERR_error_string_n(ssl_error, errorString, sizeof(errorString));
                 close_socket();
@@ -1192,10 +1188,6 @@ size_t gearman_connection_st::recv_socket(void *data, size_t data_size, gearman_
         case SSL_ERROR_SSL:
         default:
           {
-            if (ERR_peek_last_error())
-            {
-              ssl_error = ERR_peek_last_error();
-            }
             char errorString[SSL_ERROR_SIZE]= { 0 };
             ERR_error_string_n(ssl_error, errorString, sizeof(errorString));
             close_socket();

--- a/libgearman/interface/universal.hpp
+++ b/libgearman/interface/universal.hpp
@@ -46,6 +46,8 @@
 #include "libgearman/assert.hpp" 
 #include "libgearman/ssl.h"
 
+#include <cstring>
+
 enum universal_options_t
 {
   GEARMAN_UNIVERSAL_NON_BLOCKING,
@@ -68,12 +70,18 @@ struct gearman_universal_st : public error_st
     bool non_blocking;
     bool no_new_data;
     bool _ssl;
+    struct gearman_vector_st *_ssl_ca_file;
+    struct gearman_vector_st *_ssl_certificate;
+    struct gearman_vector_st *_ssl_key;
 
     Options() :
       dont_track_packets{false},
       non_blocking{false},
       no_new_data{false},
-      _ssl{false}
+      _ssl{false},
+      _ssl_ca_file{NULL},
+      _ssl_certificate{NULL},
+      _ssl_key{NULL}
     { }
   } options;
   gearman_verbose_t verbose;
@@ -208,6 +216,11 @@ struct gearman_universal_st : public error_st
 
   const char* ssl_ca_file() const
   {
+    if (options._ssl_ca_file && options._ssl_ca_file->size())
+    {
+      return options._ssl_ca_file->c_str();
+    }
+
     if (getenv("GEARMAND_CA_CERTIFICATE"))
     {
       return getenv("GEARMAND_CA_CERTIFICATE");
@@ -216,8 +229,27 @@ struct gearman_universal_st : public error_st
     return GEARMAND_CA_CERTIFICATE;
   }
 
+  void ssl_ca_file(const char* ssl_ca_file_)
+  {
+    gearman_string_free(options._ssl_ca_file);
+    size_t ssl_ca_file_size_ = 0;
+    if (ssl_ca_file_ && (ssl_ca_file_size_ = strlen(ssl_ca_file_)))
+    {
+      options._ssl_ca_file = gearman_string_create(NULL, ssl_ca_file_, ssl_ca_file_size_);
+    }
+    else
+    {
+      options._ssl_ca_file = NULL;
+    }
+  }
+
   const char* ssl_certificate() const
   {
+    if (options._ssl_certificate && options._ssl_certificate->size())
+    {
+      return options._ssl_certificate->c_str();
+    }
+
     if (getenv("GEARMAN_CLIENT_PEM"))
     {
       return getenv("GEARMAN_CLIENT_PEM");
@@ -226,14 +258,47 @@ struct gearman_universal_st : public error_st
     return GEARMAN_CLIENT_PEM;
   }
 
+  void ssl_certificate(const char *ssl_certificate_)
+  {
+    gearman_string_free(options._ssl_certificate);
+    size_t ssl_certificate_size_ = 0;
+    if (ssl_certificate_ && (ssl_certificate_size_ = strlen(ssl_certificate_)))
+    {
+      options._ssl_certificate = gearman_string_create(NULL, ssl_certificate_, ssl_certificate_size_);
+    }
+    else
+    {
+      options._ssl_certificate = NULL;
+    }
+  }
+
   const char* ssl_key() const
   {
+    if (options._ssl_key && options._ssl_key->size())
+    {
+      return options._ssl_key->c_str();
+    }
+
     if (getenv("GEARMAN_CLIENT_KEY"))
     {
       return getenv("GEARMAN_CLIENT_KEY");
     }
 
     return GEARMAN_CLIENT_KEY;
+  }
+
+  void ssl_key(const char *ssl_key_)
+  {
+    gearman_string_free(options._ssl_key);
+    size_t ssl_key_size_ = 0;
+    if (ssl_key_ && (ssl_key_size_ = strlen(ssl_key_)))
+    {
+      options._ssl_key = gearman_string_create(NULL, ssl_key_, ssl_key_size_);
+    }
+    else
+    {
+      options._ssl_key = NULL;
+    }
   }
 
 private:

--- a/libgearman/universal.hpp
+++ b/libgearman/universal.hpp
@@ -57,6 +57,9 @@ void gearman_universal_set_timeout(gearman_universal_st &self, int timeout);
 
 int gearman_universal_timeout(gearman_universal_st &self);
 
+void gearman_universal_set_ssl(gearman_universal_st &self, bool ssl,
+    const char *ca_file, const char *certificate, const char *key_file);
+
 void gearman_universal_set_namespace(gearman_universal_st &self, const char *namespace_key, size_t namespace_key_size);
 
 gearman_return_t cancel_job(gearman_universal_st& universal,

--- a/libtest/client.cc
+++ b/libtest/client.cc
@@ -378,7 +378,7 @@ bool SimpleClient::message(const char* ptr, const size_t len)
             case SSL_ERROR_SSL:
             default:
               {
-                char errorString[SSL_ERROR_SIZE];
+                char errorString[SSL_ERROR_SIZE]= { 0 };
                 ERR_error_string_n(ssl_error, errorString, sizeof(errorString));
                 error(__FILE__, __LINE__, errorString);
                 close_socket();
@@ -500,7 +500,7 @@ bool SimpleClient::response(libtest::vchar_t& response_)
             case SSL_ERROR_SSL:
             default:
               {
-                char errorString[SSL_ERROR_SIZE];
+                char errorString[SSL_ERROR_SIZE]= { 0 };
                 ERR_error_string_n(readErr, errorString, sizeof(errorString));
                 error(__FILE__, __LINE__, errorString);
                 return false;

--- a/util/instance.cc
+++ b/util/instance.cc
@@ -162,7 +162,7 @@ bool Instance::init_ssl()
   if (SSL_CTX_check_private_key(_ctx_ssl) != SSL_SUCCESS)
   {
     std::stringstream message;
-    message << "Error check private key.";
+    message << "Error checking private key";
     _last_error = message.str();
     return false;
   }

--- a/util/instance.cc
+++ b/util/instance.cc
@@ -333,10 +333,6 @@ bool Instance::run()
               case SSL_ERROR_SSL:
               default:
                 {
-                  if (ERR_peek_last_error())
-                  {
-                    ssl_error = ERR_peek_last_error();
-                  }
                   char ssl_error_buffer[SSL_ERROR_SIZE]= { 0 };
                   ERR_error_string_n(ssl_error, ssl_error_buffer, sizeof(ssl_error_buffer));
                   _last_error= ssl_error_buffer;
@@ -421,10 +417,6 @@ bool Instance::run()
                 case SSL_ERROR_SSL:
                 default:
                   {
-                    if (ERR_peek_last_error())
-                    {
-                      ssl_error = ERR_peek_last_error();
-                    }
                     char ssl_error_buffer[SSL_ERROR_SIZE]= { 0 };
                     ERR_error_string_n(ssl_error, ssl_error_buffer, sizeof(ssl_error_buffer));
                     _last_error= ssl_error_buffer;

--- a/util/instance.cc
+++ b/util/instance.cc
@@ -158,7 +158,15 @@ bool Instance::init_ssl()
     _last_error= message.str();
     return false;
   }
-#endif // defined(HAVE_WOLFSSL) && HAVE_WOLFSSL
+
+  if (SSL_CTX_check_private_key(_ctx_ssl) != SSL_SUCCESS)
+  {
+    std::stringstream message;
+    message << "Error check private key.";
+    _last_error = message.str();
+    return false;
+  }
+#endif // defined(HAVE_SSL) && HAVE_SSL
   return true;
 }
 
@@ -280,6 +288,8 @@ bool Instance::run()
             _last_error= "SSL_set_fd() failed";
             return false;
           }
+
+          SSL_set_connect_state(_ssl);
         }
 #endif
 
@@ -323,9 +333,13 @@ bool Instance::run()
               case SSL_ERROR_SSL:
               default:
                 {
-                  char wolfssl_error_buffer[SSL_ERROR_SIZE]= { 0 };
-                  ERR_error_string_n(ssl_error, wolfssl_error_buffer, sizeof(wolfssl_error_buffer));
-                  _last_error= wolfssl_error_buffer;
+                  if (ERR_peek_last_error())
+                  {
+                    ssl_error = ERR_peek_last_error();
+                  }
+                  char ssl_error_buffer[SSL_ERROR_SIZE]= { 0 };
+                  ERR_error_string_n(ssl_error, ssl_error_buffer, sizeof(ssl_error_buffer));
+                  _last_error= ssl_error_buffer;
 
                   errno= ECONNRESET;
                   write_size= SOCKET_ERROR;
@@ -407,9 +421,13 @@ bool Instance::run()
                 case SSL_ERROR_SSL:
                 default:
                   {
-                    char wolfssl_error_buffer[SSL_ERROR_SIZE]= { 0 };
-                    ERR_error_string_n(ssl_error, wolfssl_error_buffer, sizeof(wolfssl_error_buffer));
-                    _last_error= wolfssl_error_buffer;
+                    if (ERR_peek_last_error())
+                    {
+                      ssl_error = ERR_peek_last_error();
+                    }
+                    char ssl_error_buffer[SSL_ERROR_SIZE]= { 0 };
+                    ERR_error_string_n(ssl_error, ssl_error_buffer, sizeof(ssl_error_buffer));
+                    _last_error= ssl_error_buffer;
                     read_size= SOCKET_ERROR;
                     break;
                   }


### PR DESCRIPTION
There seems to be renewed interest in SSL connections from PHP to gearmand (coming up twice in the past two weeks: today on Stack Overflow and recently over at wcgallego/pecl-gearman/issues/43), so I have rebased and tweaked the patch tracked at issue #63 in the hopes of landing this.

There were also some references to `wolfssl` and `CyaTLSv1_client_method` that I have corrected or made more generic. If you prefer that I split off those minor things into a separate PR, just let me know.

The original patch came from here:
http://bugs.launchpad.net/gearmand/+bug/1338861

But I have made a few tweaks.