### PR TITLE
Correct POSTGRES misspelling

### DIFF
--- a/libtest/has.cc
+++ b/libtest/has.cc
@@ -73,7 +73,7 @@ bool has_libdrizzle(void)
 bool has_postgres_support(void)
 {
   char *getenv_ptr;
-  if (bool((getenv_ptr= getenv("POSTGES_IS_RUNNING_AND_SETUP"))))
+  if (bool((getenv_ptr= getenv("POSTGRES_IS_RUNNING_AND_SETUP"))))
   {
     (void)(getenv_ptr);
     if (HAVE_LIBPQ)


### PR DESCRIPTION
Change POSTGES_IS_RUNNING_AND_SETUP to POSTGRES_IS_RUNNING_AND_SETUP.