### PR TITLE
Fix missing init of libevent threads functions

### DIFF
--- a/gearmand/gearmand.cc
+++ b/gearmand/gearmand.cc
@@ -134,6 +134,13 @@ int main(int argc, char *argv[])
   int opt_keepalive_interval;
   int opt_keepalive_count;
 
+#ifdef EVTHREAD_USE_PTHREADS_IMPLEMENTED
+  evthread_use_pthreads();
+#endif
+
+#ifdef EVTHREAD_USE_WINDOWS_THREADS_IMPLEMENTED
+  evthread_use_windows_threads();
+#endif
 
   boost::program_options::options_description general("General options");
 


### PR DESCRIPTION
To call libevent from multiple threads, it must be initialized by
calling evthread_use_pthreads() (or evthread_use_windows_threads()) or
libevent won't protect its internal data structures against data races.

Gearman didn't call these functions and uses multiple threads by default
which caused problems like unhandled input on sockets.