### PR TITLE
Add gcc-9 and clang-9 to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,18 @@ matrix:
         artifacts: true
       env:
         - MATRIX_EVAL="CC=clang-8 && CXX=clang++-8"
+    - compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - sourceline: 'deb https://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main'
+              key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+          packages:
+            - clang-9
+        artifacts: true
+      env:
+        - MATRIX_EVAL="CC=clang-9 && CXX=clang++-9"
     - compiler: gcc
       dist: trusty
       addons:
@@ -124,6 +136,19 @@ matrix:
         artifacts: true
       env:
         - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
+    - compiler: gcc
+      dist: bionic
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - sourceline: ppa:ubuntu-toolchain-r/test
+          packages:
+            - gcc-9
+            - g++-9
+        artifacts: true
+      env:
+        - MATRIX_EVAL="CC=gcc-9 && CXX=g++-9"
 
 before_install:
   - eval "${MATRIX_EVAL}"


### PR DESCRIPTION
This PR adds gcc-9 (on Bionic) and clang-9 to the gearmand Travis CI configuration. The gcc-9 build currently fails with yet another `strncpy` truncation warning in `libtest/has.cc`. This was one wasn't noticed previously because it requires memcached and libmemcached for that code to be compiled. @zvpunry (or I) will submit a PR soon which fixes this. Once that is merged, the gcc-9 build in this PR will pass. (Tested here: https://travis-ci.org/esabol/gearmand/builds/635884516)