### PR TITLE
libtest: fix potential unterminated string

### DIFF
--- a/libtest/has.cc
+++ b/libtest/has.cc
@@ -140,7 +140,7 @@ bool has_mysqld()
   return false;
 }
 
-static char memcached_binary_path[FILENAME_MAX];
+static char memcached_binary_path[FILENAME_MAX +1]= { 0 };
 
 static void initialize_memcached_binary_path()
 {


### PR DESCRIPTION
strncpy() may not terminate the dest if it is smaller than the given
length.

This has been fixed to silence a compiler warning. It is just library
test code, nothing that could cause problems in gearman.