### PR TITLE
fix initialization of libevent2 thread support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -297,6 +297,8 @@ AX_ENABLE_LIBMEMCACHED
 AC_DEFINE([GEARMAND_BLOBSLAP_WORKER],[1],[Have Gearman Blobslap Worker])
 
 AX_LIBEVENT(,[AC_MSG_ERROR([Unable to find libevent])])
+AX_LIBEVENT2(,[AC_MSG_ERROR([Unable to find libevent2])])
+AX_LIBEVENT2_PTHREADS(,[AC_MSG_ERROR([Unable to find libevent_pthreads])])
 
 AX_UUID(,[AC_MSG_ERROR([Unable to find libuuid])])
 AX_UUID_GENERATE_TIME_SAFE

--- a/libgearman-server/gearmand.cc
+++ b/libgearman-server/gearmand.cc
@@ -239,6 +239,17 @@ gearmand_st *gearmand_create(gearmand_config_st *config,
     _exit(EXIT_FAILURE);
   }
 
+#ifdef HAVE_LIBEVENT2_PTHREADS
+  evthread_use_pthreads();
+#else
+#warn "HAVE_LIBEVENT2_PTHREADS not defined, can't initialize thread-support. This build will emit warnings and disable threads."
+  if (threads_arg > 0)
+  {
+    threads_arg= 0;
+    gearmand_log_warning("Threads disabled because this build could not locate libevent2 or its pthreads support.");
+  }
+#endif
+
   gearmand_st* gearmand= new (std::nothrow) gearmand_st(host_arg, threads_arg, backlog_arg, verbose_arg, exceptions_);
   if (gearmand == NULL)
   {

--- a/libgearman-server/gearmand.h
+++ b/libgearman-server/gearmand.h
@@ -50,6 +50,11 @@
 
 #include <event.h>
 
+#ifdef HAVE_LIBEVENT2
+#include <event2/event.h>
+#include <event2/thread.h>
+#endif
+
 #include <libgearman-1.0/visibility.h>
 #include <libgearman-1.0/protocol.h>
 

--- a/libgearman-server/include.am
+++ b/libgearman-server/include.am
@@ -88,6 +88,7 @@ libgearman_server_libgearman_server_la_CXXFLAGS+= -DBUILDING_LIBGEARMAN
 
 libgearman_server_libgearman_server_la_LIBADD+= @LIBEVENT_LIB@
 libgearman_server_libgearman_server_la_LIBADD+= @PTHREAD_LIBS@
+libgearman_server_libgearman_server_la_LIBADD+= @LIBEVENT2_PTHREADS_LIB@
 libgearman_server_libgearman_server_la_LIBADD+= @BOOST_PROGRAM_OPTIONS_LIB@
 libgearman_server_libgearman_server_la_LIBADD+= @LIBM@
 libgearman_server_libgearman_server_la_LIBADD+= @lt_cv_dlopen_libs@

--- a/m4/ax_libevent.m4
+++ b/m4/ax_libevent.m4
@@ -6,6 +6,7 @@
 #   AX_LIBEVENT([ACTION-IF-FOUND[, ACTION-IF-NOT-FOUND]]) 
 #   AX_LIBEVENT2() 
 #   AX_LIBEVENT2_EVHTTP()
+#   AX_LIBEVENT2_PTHREADS()
 #
 # DESCRIPTION
 #
@@ -20,7 +21,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 5
+#serial 6
  
 AC_DEFUN([AX_LIBEVENT],
          [AC_PREREQ([2.63])dnl
@@ -126,3 +127,35 @@ AC_DEFUN([AX_LIBEVENT2_EVHTTP],
         [$1],
         [$2])
     ])dnl AX_LIBEVENT2_EVHTTP
+
+#
+AC_DEFUN([AX_LIBEVENT2_PTHREADS],
+    [AC_REQUIRE([AX_LIBEVENT2])
+    AC_CACHE_CHECK([test for a working libevent pthreads interface], [ax_cv_libevent2_pthreads],
+      [AX_SAVE_FLAGS
+      CFLAGS="-pthread $CFLAGS"
+      LIBS="-levent_pthreads -levent $LIBS"
+      AC_LANG_PUSH([C])
+      AC_RUN_IFELSE([AC_LANG_PROGRAM([[
+#include <event2/thread.h>
+          ]],[[
+          evthread_use_pthreads();
+          ]])],
+        [ax_cv_libevent2_pthreads=yes],
+        [ax_cv_libevent2_pthreads=no],
+        [AC_MSG_WARN([test program execution failed])])
+      AC_LANG_POP([C])
+      AX_RESTORE_FLAGS
+      ])
+
+    AS_IF([test "x$ax_cv_libevent2_pthreads" = "xyes"],
+        [AC_SUBST([LIBEVENT2_PTHREADS_LIB],[-levent_pthreads])
+        AC_DEFINE([HAVE_LIBEVENT2_PTHREADS],[1],[Define if evthread_use_pthreads is present in event2/thread.h.])],
+        [AC_DEFINE([HAVE_LIBEVENT2_PTHREADS],[0],[Define if evthread_use_pthreads is present in event2/thread.h.])])
+
+    AM_CONDITIONAL([HAVE_LIBEVENT2_PTHREADS],[test "x$ax_cv_libevent2_pthreads" = xyes])
+# Finally, execute ACTION-IF-FOUND/ACTION-IF-NOT-FOUND:
+    AS_IF([test "x$ax_cv_libevent2_pthreads" = xyes],
+        [$1],
+        [$2])
+    ])dnl AX_LIBEVENT2_PTHREADS


### PR DESCRIPTION
gearmand depends on libevent2, it checked only for libevent. It used
libevent2 anyways but without initializing its thread support.

This should fix it.