### PR TITLE
Fix crashing of tests when '-Wp,-D_GLIBCXX_ASSERTIONS' is given

### DIFF
--- a/libtest/cmdline.h
+++ b/libtest/cmdline.h
@@ -153,7 +153,7 @@ public:
 
   const char* stdout_c_str() const
   {
-    return &_stdout_buffer[0];
+    return _stdout_buffer.size() ? &_stdout_buffer[0] : NULL;
   }
 
   libtest::vchar_t stderr_result() const
@@ -163,7 +163,7 @@ public:
 
   const char* stderr_c_str() const
   {
-    return &_stderr_buffer[0];
+    return _stderr_buffer.size() ? &_stderr_buffer[0] : NULL;
   }
 
   size_t stderr_result_length() const

--- a/tests/hostile.cc
+++ b/tests/hostile.cc
@@ -136,7 +136,7 @@ extern "C" {
         gearman_return_t rc;
         void *value= gearman_client_do(&client, WORKER_FUNCTION_NAME,
                                        NULL,
-                                       &payload[0], 
+                                       payload.size() ? &payload[0] : NULL,
                                        payload.size() ? random() % payload.size() : 0,
                                        NULL, &rc);
 


### PR DESCRIPTION
If 'vec' is a vector, calling 'vec[0]' will crash the program if
'vec' is empty and '-Wp,-D_GLIBCXX_ASSERTIONS' given in CXXFLAGS.

Fixes https://github.com/gearman/gearmand/issues/272