### PR TITLE
Add CXXFLAGS=-Wp,-D_GLIBCXX_ASSERTIONS to the gcc-9 build in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -148,7 +148,7 @@ matrix:
             - g++-9
         artifacts: true
       env:
-        - MATRIX_EVAL="CC=gcc-9 && CXX=g++-9"
+        - MATRIX_EVAL="CC=gcc-9 && CXX=g++-9 && CXXFLAGS=-Wp,-D_GLIBCXX_ASSERTIONS"
 
 before_install:
   - eval "${MATRIX_EVAL}"


### PR DESCRIPTION
As discussed in issue #272, ensure C++ STL is used properly, according to `_GLIBCXX_ASSERTIONS`. This only adds it to the gcc-9 build. Let me know if you think it should be added to other gcc/g++ builds.

Reference:
https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_macros.html