### PR TITLE
.travis.yml: Removed deprecated sudo tag and changed the matrix tag to jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os:
 language: cpp
 dist: xenial
 
-matrix:
+jobs:
   include:
     - compiler: clang
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ os:
   - linux
 language: cpp
 dist: xenial
-sudo: required
 
 matrix:
   include:


### PR DESCRIPTION
I noticed that under "View config" on Travis CI, it says:
```
root: deprecated key sudo (The key `sudo` has no effect anymore.)
```
I googled that and found this blog entry:
* https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

All the Python repos subsequently removed `sudo: required` from their `.travis.yml` files. For example: https://github.com/python/mypy/issues/6675

We might as well do the same!