### PR TITLE
Fix error: ‘environ’ was declared ‘extern’ and later ‘static’ [-fpermissive]

### DIFF
--- a/libtest/cmdline.cc
+++ b/libtest/cmdline.cc
@@ -61,8 +61,11 @@ using namespace libtest;
 #include <algorithm>
 #include <stdexcept>
 
-#ifndef __USE_GNU
-static char **environ= NULL;
+#if defined(__APPLE__) && __APPLE__
+# include <crt_externs.h>
+# define environ (*_NSGetEnviron ())
+#elif !defined(_GNU_SOURCE)
+extern char **environ= NULL;
 #endif
 
 #ifndef FD_CLOEXEC


### PR DESCRIPTION
Hello,

I'm not sure about this fix. 

In the CPANTesters I noticed this error : 

```
libtest/cmdline.cc:65:15: error: 'environ' was declared 'extern' and later 'static' [-fpermissive]
   65 | static char **environ= NULL;
      |               ^~~~~~~
In file included from /usr/include/fortify/unistd.h:22,
                 from ./libtest/common.h:77,
                 from libtest/cmdline.cc:39:
/usr/include/unistd.h:183:15: note: previous declaration of 'environ'
  183 | extern char **environ;
      |               ^~~~~~~
```

From http://www.cpantesters.org/cpan/report/003e64ec-ca05-11ea-9066-e374b0ba08e8 (it is on an alpine Linux)

From the [git blame](https://github.com/gearman/gearmand/blame/master/libtest/cmdline.cc#L65) it was added for OSX. I have tested with and without #ifdef on my machine but I have not tested on OSX... 

 Best regards.

Thibault