### PR TITLE
Add github ci for alpine and static

### DIFF
--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -1,0 +1,21 @@
+name : alpine
+
+on:
+  push
+
+jobs:
+  gearman:
+    runs-on: ubuntu-latest
+    container: alpine
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install deps 
+        run:
+          apk add musl-dev gcc g++ autoconf automake m4 git make util-linux-dev libuuid libevent-dev gperf boost-dev 
+      - name: Configure
+        run:
+          ./configure
+      - name: Make
+        run: 
+          make 

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,0 +1,20 @@
+name: static
+
+on:
+  push
+  
+jobs:
+  gearman:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install deps 
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y libboost-all-dev gperf libevent-dev uuid-dev python-sphinx libhiredis-dev
+      - name: Configure
+        run: 
+          ./configure --disable-shared
+      - name: Make
+        run: 
+          make LIBS=-lstdc++


### PR DESCRIPTION
Hello,

Some new CI jobs so it could alert quickly if a commit breaks a different libc or a different linking method.

Could be nice to have a macos job also, but I got various non trivial errors when I tried... that's why it's not part of this PR :grin: 
Feel free to reimplement in travis if you prefer, but to my eyes it looked like more like a big compiler variants and versions check and I felt not comfortable to add it to travis.

Regards.

Thibault