### PR TITLE
Issue #293: Bootstrap on Alpine

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -194,6 +194,9 @@ set_VENDOR_DISTRIBUTION ()
     opensuse*)
       VENDOR_DISTRIBUTION='opensuse'
       ;;
+    alpine)
+      VENDOR_DISTRIBUTION='alpine'
+      ;;
     *)
       die "attempt to set an invalid VENDOR_DISTRIBUTION=$dist"
       ;;
@@ -263,6 +266,9 @@ set_VENDOR_RELEASE ()
     opensuse)
       VENDOR_RELEASE="$release"
       ;;
+    alpine)
+      VENDOR_RELEASE="$release"
+      ;;
     unknown)
       die "attempt to set VENDOR_RELEASE without setting VENDOR_DISTRIBUTION"
       ;;
@@ -273,13 +279,16 @@ set_VENDOR_RELEASE ()
 }
 
 
-#  Valid values are: apple, redhat, centos, canonical, oracle, suse
+#  Valid values are: alpine, apple, redhat, centos, canonical, oracle, suse
 set_VENDOR ()
 {
   local vendor
   vendor="$(echo "$1" | tr '[:upper:]' '[:lower:]')"
 
   case $vendor in
+    alpine)
+      VENDOR='alpine'
+      ;;
     apple)
       VENDOR='apple'
       ;;
@@ -372,6 +381,10 @@ determine_target_platform ()
     # shellcheck disable=SC1091
     source '/etc/lsb-release'
     set_VENDOR 'canonical' "$DISTRIB_ID" "$DISTRIB_CODENAME"
+  elif [[ -f '/etc/alpine-release' ]]; then
+    local alpine_version
+    alpine_version="$(cat /etc/alpine-release)"
+    set_VENDOR 'alpine' 'alpine' "$alpine_version"
   fi
 
   rebuild_host_os

--- a/libhashkit/common.h
+++ b/libhashkit/common.h
@@ -39,6 +39,7 @@
 
 #include "libhashkit/hashkitcon.h"
 
+#include <limits.h>
 #include <assert.h>
 #include <errno.h>
 #include <stdio.h>
@@ -46,10 +47,18 @@
 #include <math.h>
 
 #ifndef __WORDSIZE
-# ifdef __MINGW32__
+# if defined(__MINGW32__)
 #  define __WORDSIZE 32
-# endif
-#endif
+# elif defined(LONG_BITS)
+#  if (LONG_BITS == 32)
+#   define __WORDSIZE 32
+#  else
+#   define __WORDSIZE 64
+#  endif /* defined(LONG_BITS) */
+# else
+#  define __WORDSIZE 64
+# endif /* defined(__MINGW32__) */
+#endif /* __WORDSIZE */
 
 #include <libhashkit-1.0/hashkit.h>
 #include "libhashkit/algorithm.h"


### PR DESCRIPTION
This PR addresses issue #293 and adds support for bootstrapping on Alpine Linux.

I did some additional research into `__WORDSIZE`, and what I saw was a confusing mess, as usual whenever I seem to look into C preprocessor macros. I saw a lot of recommendations to use `__BITS_PER_LONG` or `BITS_PER_LONG` or `LONG_BITS` instead. Plus a whole host of other methods. I eventually came across this Alpine patch for libmemcached:

https://git.alpinelinux.org/aports/plain/main/libmemcached/musl-fixes.patch

That at least gave me confidence to add some checks for `LONG_BITS`. Should I add `__BITS_PER_LONG` or `BITS_PER_LONG` too? Am I overcomplicating this? Probably!

And I think you need to `#include <limits.h>`. I didn't see an `#include` for that, but maybe I missed it somewhere. Anyway, I added it, mainly because the above Alpine patch also had it. What do you think?

References:
https://www.linuxquestions.org/questions/programming-9/c-preprocessor-define-for-32-vs-64-bit-long-int-4175658579/
https://www.google.com/search?q=c+preprocessor+detect+%22wordsize%22+site:stackoverflow.com