### PR TITLE
Use suseconds_t instead of long

### DIFF
--- a/libgearman-server/connection.cc
+++ b/libgearman-server/connection.cc
@@ -719,7 +719,7 @@ gearmand_error_t gearman_server_con_add_job_timeout(gearman_server_con_st *con, 
         struct timeval timeout_tv = { 0 , 0 };
         time_t milliseconds= worker->timeout;
         timeout_tv.tv_sec= milliseconds / 1000;
-        timeout_tv.tv_usec= (long)((milliseconds % 1000) * 1000);
+        timeout_tv.tv_usec= (suseconds_t)((milliseconds % 1000) * 1000);
         timeout_add(con->timeout_event, &timeout_tv);
       }
       else if (con->timeout_event) // Delete the timer if it exists


### PR DESCRIPTION
As mentioned in issue #291, this addresses the following compilation warning seen on at least some versions of macOS (neé Mac OS X):
```
libgearman-server/connection.cc:722:29: warning: implicit conversion loses integer precision: 'long' to
      '__darwin_suseconds_t' (aka 'int') [-Wshorten-64-to-32]
        timeout_tv.tv_usec= (long)((milliseconds % 1000) * 1000);
```
At least some versions of macOS, Apple apparently used `int` instead of `long` for `tv_usec` in `struct timeval`. The solution is to use `suseconds_t` for the type instead.

This works on Linux as well in my testing, but does anyone think this change should only be made on macOS? If so, I could make it this instead:
```C
#ifdef __APPLE__
        timeout_tv.tv_usec= (suseconds_t)((milliseconds % 1000) * 1000);
#else
        timeout_tv.tv_usec= (long)((milliseconds % 1000) * 1000);
#endif
```
Let me know if that's preferable.