### PR TITLE
Fix misspellings of "occurred"

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -257,7 +257,7 @@ be able to handle multiple servers.
  * Check to make sure worker job results match assigned worker.
 
 0.12 Thu Feb 18 11:28:49 PST 2010
- * Fixed bug where memory loss occured if data was too large.
+ * Fixed bug where memory loss occurred if data was too large.
  * Added gearman_strerror().
  * Fixed bug where setting an option off in mass would not trip any triggers on the option (for both worker and client).
  * Options that are internal can no longer be set by external callers.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1794,7 +1794,7 @@ merge ()
 
     bzr push "$BRANCH"
   elif [[ -n "$VCS_CHECKOUT" ]]; then
-    die "Merge attempt occured, current VCS setup does not support this"
+    die "Merge attempt occurred, current VCS setup does not support this"
   fi
 }
 


### PR DESCRIPTION
When I was young, I won my school's spelling bee 🥇 and competed at the state level of the National Spelling Bee, so I'm somewhat sensitive to spelling errors. 🙂