### PR TITLE
Fix Travis CI builds after migration to travis-ci.com

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ jobs:
         artifacts: true
       env:
         - MATRIX_EVAL="CC=clang-8 && CXX=clang++-8"
-    - compiler: clang
+    - compiler: clang-9
       addons:
         apt:
           sources:
@@ -158,6 +158,7 @@ before_script:
   - export -f travis_fold
 
 script:
+  - eval "${MATRIX_EVAL}"
   - ${CC} --version
   - ./bootstrap.sh -a
   - ./configure --enable-ssl

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ dist: xenial
 
 jobs:
   include:
-    - compiler: clang
+    - compiler: clang-4.0
       addons:
         apt:
           sources:
@@ -15,7 +15,7 @@ jobs:
         artifacts: true
       env:
         - MATRIX_EVAL="CC=clang-4.0 && CXX=clang++-4.0"
-    - compiler: clang
+    - compiler: clang-5.0
       addons:
         apt:
           sources:
@@ -25,7 +25,7 @@ jobs:
         artifacts: true
       env:
         - MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0"
-    - compiler: clang
+    - compiler: clang-6.0
       addons:
         apt:
           sources:
@@ -35,7 +35,7 @@ jobs:
         artifacts: true
       env:
         - MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0"
-    - compiler: clang
+    - compiler: clang-7
       addons:
         apt:
           sources:
@@ -45,7 +45,7 @@ jobs:
         artifacts: true
       env:
         - MATRIX_EVAL="CC=clang-7 && CXX=clang++-7"
-    - compiler: clang
+    - compiler: clang-8
       addons:
         apt:
           sources:
@@ -67,7 +67,7 @@ jobs:
         artifacts: true
       env:
         - MATRIX_EVAL="CC=clang-9 && CXX=clang++-9"
-    - compiler: gcc
+    - compiler: gcc-4.8
       dist: trusty
       addons:
         apt:
@@ -79,7 +79,7 @@ jobs:
         artifacts: true
       env:
         - MATRIX_EVAL="CC=gcc-4.8 && CXX=g++-4.8"
-    - compiler: gcc
+    - compiler: gcc-4.9
       dist: trusty
       addons:
         apt:
@@ -91,7 +91,7 @@ jobs:
         artifacts: true
       env:
         - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
-    - compiler: gcc
+    - compiler: gcc-5
       addons:
         apt:
           sources:
@@ -102,7 +102,7 @@ jobs:
         artifacts: true
       env:
         - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
-    - compiler: gcc
+    - compiler: gcc-6
       addons:
         apt:
           sources:
@@ -113,7 +113,7 @@ jobs:
         artifacts: true
       env:
         - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
-    - compiler: gcc
+    - compiler: gcc-7
       addons:
         apt:
           sources:
@@ -124,7 +124,7 @@ jobs:
         artifacts: true
       env:
         - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
-    - compiler: gcc
+    - compiler: gcc-8
       addons:
         apt:
           sources:
@@ -135,7 +135,7 @@ jobs:
         artifacts: true
       env:
         - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
-    - compiler: gcc
+    - compiler: gcc-9
       dist: bionic
       addons:
         apt:
@@ -158,7 +158,6 @@ before_script:
   - export -f travis_fold
 
 script:
-  - eval "${MATRIX_EVAL}"
   - ${CC} --version
   - ./bootstrap.sh -a
   - ./configure --enable-ssl

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 gearmand
 ========
 
-[![Build Status](https://travis-ci.org/gearman/gearmand.png)](https://travis-ci.org/gearman/gearmand)
+[![Build Status](https://app.travis-ci.com/gearman/gearmand.svg?branch=master)](https://app.travis-ci.com/github/gearman/gearmand)
 
 The latest version of ```gearmand``` source code and versions 1.1.13 and later can be found at [GitHub Repository](https://github.com/gearman/gearmand). Older versions released before 1.1.13 can be found at [Launchpad Repository](http://launchpad.net/gearmand/).
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -255,11 +255,11 @@ set_VENDOR_RELEASE ()
       ;;
     ubuntu)
       VENDOR_RELEASE="$release"
-      if [[ "x$VENDOR_RELEASE" == 'x12.04' ]]; then
+      if [[ "z$VENDOR_RELEASE" == 'z12.04' ]]; then
         VENDOR_RELEASE="precise"
-      elif [[ "x$VENDOR_RELEASE" == 'x12.10' ]]; then
+      elif [[ "z$VENDOR_RELEASE" == 'z12.10' ]]; then
         VENDOR_RELEASE="quantal"
-      elif [[ "x$VENDOR_RELEASE" == 'x13.04' ]]; then
+      elif [[ "z$VENDOR_RELEASE" == 'z13.04' ]]; then
         VENDOR_RELEASE="raring"
       fi
       ;;

--- a/scripts/travis-linux.sh
+++ b/scripts/travis-linux.sh
@@ -1,3 +1,6 @@
 sudo apt-get update -qq
 COMPILER_PACKAGE=$CXX
+if echo "$COMPILER_PACKAGE" | grep -q '^clang++-'; then
+    COMPILER_PACKAGE=$CC
+fi
 sudo apt-get install -y libboost-all-dev gperf libevent-dev uuid-dev python-sphinx libhiredis-dev $COMPILER_PACKAGE


### PR DESCRIPTION
We've finally migrated to travis-ci.com from travis-ci.org! Unfortunately, after the migration, the clang-9 and Ubuntu Bionic gcc-9 builds were failing. This PR fixes that.