### PR TITLE
Issue #321: Improve compatibility with older versions of Alpine

### DIFF
--- a/libtest/cmdline.cc
+++ b/libtest/cmdline.cc
@@ -205,7 +205,7 @@ Application::error_t Application::run(const char *args[])
   fatal_assert(posix_spawnattr_setsigmask(&spawnattr, &mask) == 0);
 
 #if defined(POSIX_SPAWN_USEVFORK) || defined(__GLIBC__)
-  // Use USEVFORK where appropriate
+  // Use USEVFORK where appropriate.
   flags |= POSIX_SPAWN_USEVFORK;
 #endif
 

--- a/libtest/cmdline.cc
+++ b/libtest/cmdline.cc
@@ -205,7 +205,7 @@ Application::error_t Application::run(const char *args[])
   fatal_assert(posix_spawnattr_setsigmask(&spawnattr, &mask) == 0);
 
 #if defined(POSIX_SPAWN_USEVFORK) || defined(__GLIBC__)
-  // Use USEVFORK where appropriate.
+  // Use USEVFORK where appropriate
   flags |= POSIX_SPAWN_USEVFORK;
 #endif
 

--- a/libtest/cmdline.cc
+++ b/libtest/cmdline.cc
@@ -204,8 +204,8 @@ Application::error_t Application::run(const char *args[])
 
   fatal_assert(posix_spawnattr_setsigmask(&spawnattr, &mask) == 0);
 
-#if defined(POSIX_SPAWN_USEVFORK) || defined(__linux__)
-  // Use USEVFORK on linux
+#if defined(POSIX_SPAWN_USEVFORK) || defined(__GLIBC__)
+  // Use USEVFORK where appropriate
   flags |= POSIX_SPAWN_USEVFORK;
 #endif
 


### PR DESCRIPTION
This should improve compatibility with older versions of Alpine/MUSL that didn't define `POSIX_SPAWN_USEVFORK` but did define `__linux__`, obviously. With this change, `POSIX_SPAWN_USEVFORK` is only used if it is defined or if glibc is being used.

This change replicates [a similar change made to the same file in the libmemcached project](https://git.alpinelinux.org/aports/tree/main/libmemcached/musl-fixes.patch).