### PR TITLE
Fix Postgres queue table creation on startup

### DIFF
--- a/libgearman-server/plugins/queue/postgres/queue.cc
+++ b/libgearman-server/plugins/queue/postgres/queue.cc
@@ -130,7 +130,7 @@ Postgres::~Postgres ()
 
 gearmand_error_t Postgres::initialize()
 {
-  _create_query+= "CREATE TABLE " +table +" (unique_key VARCHAR" +"(" + TOSTRING(GEARMAN_UNIQUE_SIZE) +"), ";
+  _create_query+= "CREATE TABLE IF NOT EXISTS " +table +" (unique_key VARCHAR" +"(" + TOSTRING(GEARMAN_UNIQUE_SIZE) +"), ";
   _create_query+= "function_name VARCHAR(255), priority INTEGER, data BYTEA, when_to_run INTEGER, UNIQUE (unique_key, function_name))";
 
   gearmand_error_t ret= _initialize(Gearmand()->server, this);

--- a/libgearman-server/plugins/queue/postgres/queue.cc
+++ b/libgearman-server/plugins/queue/postgres/queue.cc
@@ -130,6 +130,7 @@ Postgres::~Postgres ()
 
 gearmand_error_t Postgres::initialize()
 {
+  // "IF NOT EXISTS" added in Postgres 9.1
   _create_query+= "CREATE TABLE IF NOT EXISTS " +table +" (unique_key VARCHAR" +"(" + TOSTRING(GEARMAN_UNIQUE_SIZE) +"), ";
   _create_query+= "function_name VARCHAR(255), priority INTEGER, data BYTEA, when_to_run INTEGER, UNIQUE (unique_key, function_name))";
 


### PR DESCRIPTION
when table name contains schema name like `foo.bar`, gearman can't find it in database because it uses query `SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME  = ...` and `TABLE_NAME` column data contains only `bar` part so each time on startup it tries to recreate it and on second start it fails `PQexec:ERROR:  relation "bar" already exists`

this is a quick fix, correct fix is to add non-default schema support but this way it will work at least

**COMPATIBILITY NOTE**: `IF NOT EXISTS` added in Postgres 9.1