### PR TITLE
Refine GitHub Actions CI workflow to support a matrix of compiler versions

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,4 +1,4 @@
-name: C/C++ CI
+name: GitHub Actions CI
 
 on:
   push:
@@ -9,13 +9,98 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    name: ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}
+    container: ${{ matrix.config.container }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {name: 'ubuntu-14.04 gcc-4.8', os: ubuntu-latest, container: 'ubuntu:14.04', cc: 'gcc', cxx: 'g++', tag: '4.8', toolchain: 'ppa:ubuntu-toolchain-r/test'}
+          - {name: 'ubuntu-14.04 gcc-4.9', os: ubuntu-latest, container: 'ubuntu:14.04', cc: 'gcc', cxx: 'g++', tag: '4.9', toolchain: 'ppa:ubuntu-toolchain-r/test'}
+          - {name: 'ubtunu-18.04 gcc-5', os: ubuntu-18.04, cc: 'gcc', cxx: 'g++', tag: '5'}
+          - {name: 'ubtunu-18.04 gcc-6', os: ubuntu-18.04, cc: 'gcc', cxx: 'g++', tag: '6'}
+          - {name: 'ubtunu-18.04 gcc-7', os: ubuntu-18.04, cc: 'gcc', cxx: 'g++', tag: '7'}
+          - {name: 'ubtunu-18.04 gcc-8', os: ubuntu-18.04, cc: 'gcc', cxx: 'g++', tag: '8'}
+          - {name: 'ubtunu-20.04 gcc-9', os: ubuntu-20.04, cc: 'gcc', cxx: 'g++', tag: '9'}
+          - {name: 'ubtunu-20.04 gcc-10', os: ubuntu-20.04, cc: 'gcc', cxx: 'g++', tag: '10'}
+          - {name: 'ubtunu-20.04 gcc-11', os: ubuntu-20.04, cc: 'gcc', cxx: 'g++', tag: '11'}
+
+    env:
+      CC: ${{ matrix.config.cc }}-${{ matrix.config.tag }}
+      CXX: ${{ matrix.config.cxx }}-${{ matrix.config.tag }}
+      GHA_CONTAINER: ${{ matrix.config.container }}
 
     steps:
+    - name: if running in a container, update and install sudo, git, and other basics
+      if: matrix.config.container != ''
+      run: |
+          apt-get -o Acquire::Retries=3 update && DEBIAN_FRONTEND=noninteractive apt-get -o Acquire::Retries=3 -y install tzdata sudo apt-transport-https make apt-file software-properties-common libssl-dev build-essential autotools-dev autoconf automake pkgconf
+          sudo apt-add-repository ppa:git-core/ppa
+          sudo apt-get -o Acquire::Retries=3 update && apt-get -o Acquire::Retries=3 -y install git
+    - name: override DNS to fix IP address for hostname in some Docker containers
+      if: matrix.config.container == 'ubuntu:14.04'
+      run: |
+        echo "==="
+        echo "Before: /etc/hosts"
+        cat /etc/hosts
+        echo "==="
+        echo "Removing localhost name from ::1 entry in /etc/hosts..."
+        sed 's/^::1\s\s*localhost\s\(.*\)/::1 \1/' /etc/hosts > /tmp/hosts.temp
+        cp /tmp/hosts.temp /etc/hosts
+        rm /tmp/hosts.temp
+        echo "After: /etc/hosts"
+        cat /etc/hosts
+        echo "==="
+        ip addr
+        echo "==="
+        echo "'hostname -i' shows '$(hostname -i)'"
+        echo "'hostname -I' shows '$(hostname -I)'"
+        echo "'hostname -s' shows '$(hostname -s)'"
+        echo "'hostname -f' shows '$(hostname -f)'"
+    - name: configure toolchain (optional)
+      if: matrix.config.toolchain != ''
+      run: |
+          sudo apt-add-repository ${{ matrix.config.toolchain }}
+          sudo apt-get update
+          sudo apt-get -y install libtool
     - uses: actions/checkout@v2
+    - name: tweak multi_client_test.cc for container usage
+      if: matrix.config.container == 'ubuntu:14.04'
+      run: |
+        echo "==="
+        echo "Before multi_client_test.cc:"
+        grep push_port tests/libgearman-1.0/multi_client_test.cc
+        echo "Changing multi_client_test.cc..."
+        sed -i -e '0,/test->push_port.*libtest/ s/\(test.*push_port(\).*libtest.*\();\)/\1 19298 \2/' tests/libgearman-1.0/multi_client_test.cc
+        sed -i -e '0,/test->push_port.*libtest/ s/\(test.*push_port(\).*libtest.*\();\)/\1 19300 \2/' tests/libgearman-1.0/multi_client_test.cc
+        echo "After multi_client_test.cc:"
+        grep push_port tests/libgearman-1.0/multi_client_test.cc
+        echo "==="
     - name: install dependencies
-      run: sudo apt-get install -y libboost-all-dev gperf libevent-dev uuid-dev sphinx-doc sphinx-common libhiredis-dev gcc g++
+      run: |
+          sudo apt-get update && sudo apt-get -o Acquire::Retries=3 install -y libboost-all-dev gperf libevent-dev uuid-dev sphinx-doc sphinx-common libhiredis-dev ${{ matrix.config.cc }}-${{ matrix.config.tag }} ${{ matrix.config.cxx }}-${{ matrix.config.tag }}
     - name: bootstrap
-      run: ./bootstrap.sh
-    - name: make check
-      run: make check
+      run: |
+           if [ -n "$GHA_CONTAINER" ]; then
+              echo "container: $GHA_CONTAINER"
+           fi
+           if [ -f "/etc/lsb-release" ]; then
+              cat /etc/lsb-release
+           fi
+           ./bootstrap.sh -a
+    - name: configure
+      run: ./configure --enable-ssl
+    - name: make
+      run: ${CC} --version && make
+    - name: make test
+      run: ${CC} --version && make test
+    - name: check test-suite.log
+      if: success() || failure()
+      run: |
+           if [ -f "./test-suite.log" ]; then
+              cat ./test-suite.log
+           else
+              echo "No test-suite.log file found."
+           fi

--- a/libgearman-server/gearmand.cc
+++ b/libgearman-server/gearmand.cc
@@ -852,13 +852,13 @@ static void _listen_clear(gearmand_st *gearmand)
 static void _listen_event(int event_fd, short events __attribute__ ((unused)), void *arg)
 {
   gearmand_port_st *port= (gearmand_port_st *)arg;
-  struct sockaddr_storage sa;
+  struct sockaddr sa;
 
   socklen_t sa_len= sizeof(sa);
 #if defined(HAVE_ACCEPT4) && HAVE_ACCEPT4
-  int fd= accept4(event_fd, (struct sockaddr *)&sa, &sa_len, SOCK_NONBLOCK); //  SOCK_NONBLOCK);
+  int fd= accept4(event_fd, &sa, &sa_len, SOCK_NONBLOCK); //  SOCK_NONBLOCK);
 #else
-  int fd= accept(event_fd, (struct sockaddr *)&sa, &sa_len);
+  int fd= accept(event_fd, &sa, &sa_len);
 #endif
 
   if (fd == -1)
@@ -890,8 +890,7 @@ static void _listen_event(int event_fd, short events __attribute__ ((unused)), v
   */
   char host[NI_MAXHOST];
   char port_str[NI_MAXSERV];
-  int error= getnameinfo((struct sockaddr *)&sa, sa_len, host, NI_MAXHOST,
-                         port_str, NI_MAXSERV,
+  int error= getnameinfo(&sa, sa_len, host, NI_MAXHOST, port_str, NI_MAXSERV,
                          NI_NUMERICHOST | NI_NUMERICSERV);
   if (error != 0)
   {


### PR DESCRIPTION
This PR refines the GitHub Actions CI workflow to support a matrix of compiler versions. This is needed so that we can "retire" Travis CI.

I'd like to rename the `.github/workflow/c-cpp.yml` file to `ci.yml`, but I haven't done that yet. Let me know what you think about that.