### PR TITLE
Fix bug in prioritystatus

### DIFF
--- a/libgearman-server/text.cc
+++ b/libgearman-server/text.cc
@@ -136,7 +136,7 @@ gearmand_error_t server_run_text(gearman_server_con_st *server_con,
           job_queued[priority] = 0;
           for (gearman_server_job_st *server_job= function->job_list[priority];
                server_job != NULL;
-               server_job= server_job->next)
+               server_job= server_job->function_next)
           {
             job_queued[priority]++;
           }


### PR DESCRIPTION
This has never been correct, and has only ever shown 1 if there are any
in a priority, or 0 if there are not. That is because the next
struct field that as used is confusingly not maintained in this context.

Closes #337