### PR TITLE
Issue #317: MAN file for gearadmin was missing commands

### DIFF
--- a/docs/source/bin/gearadmin.rst
+++ b/docs/source/bin/gearadmin.rst
@@ -46,6 +46,30 @@ SYNOPSIS
 
    Workers for the server.
 
+.. option:: --cancel-job
+
+   Remove a given job from the server's queue.
+
+.. option:: --show-unique-jobs
+
+   Show unique IDs of jobs on the server.
+
+.. option:: --show-jobs
+
+   Show all jobs on the server.
+
+.. option:: --getpid
+
+   Get Process ID for the server.
+
+.. option:: --priority-status
+
+   Queued jobs status by priority.
+
+.. option:: -S [ --ssl ]
+
+   Enable SSL connections.
+
 
 -----------
 DESCRIPTION


### PR DESCRIPTION
The following were added:

```bash
--cancel-job
--show-unique-jobs
--show-jobs
--getpid
--priority-status
-S [ --ssl ]
```

Closes #317 