### PR TITLE
Updated docs: The verbose text command only READS the verbose setting

### DIFF
--- a/docs/source/protocol/text.rst
+++ b/docs/source/protocol/text.rst
@@ -44,7 +44,7 @@ The following list represents the current list of commands supported. You can is
 
 .. describe:: verbose
 
-   Change the verbose level of the server.
+   Return the verbose level of the server.
 
 .. describe:: version
    


### PR DESCRIPTION
proof: https://github.com/gearman/gearmand/blob/master/libgearman-server/text.cc#L363