### PR TITLE
prioritystatus was in gearmand binary but not in docs

### DIFF
--- a/docs/source/protocol/text.rst
+++ b/docs/source/protocol/text.rst
@@ -49,3 +49,8 @@ The following list represents the current list of commands supported. You can is
 .. describe:: version
    
    Version number of server.
+
+.. describe:: prioritystatus
+
+   Queued jobs status by priority.
+


### PR DESCRIPTION
```bash
[octavn@dev ~]$ gearadmin --priority-status
convert	0	0	0	25
.
[octavn@dev ~]$ telnet localhost 4730
Trying ::1...
Connected to localhost.
Escape character is '^]'.
prioritystatus
convert	0	0	0	25
.
```