### PR TITLE
Issue #346: Remove reliance on gearman.info website from tests

### DIFF
--- a/libtest/dns.cc
+++ b/libtest/dns.cc
@@ -101,14 +101,14 @@ bool check_dns()
     return false;
   }
 
-  if (lookup("exist.gearman.info") == false)
+  if (lookup("www.google.com") == false)
   {
     return false;
   }
 
-  if (lookup("does_not_exist.gearman.info")) // This should fail, if it passes,...
+  if (lookup("does_not_exist.google.com")) // This should fail, if it passes,...
   {
-    fatal_assert("Your service provider sucks and is providing bogus DNS. You might be in an airport.");
+    fatal_assert("Your service provider is providing bogus DNS. You might be in an airport.");
   }
 
   return true;

--- a/tests/libgearman-1.0/client_test.cc
+++ b/tests/libgearman-1.0/client_test.cc
@@ -798,7 +798,7 @@ static test_return_t add_servers_test(void *)
   if (libtest::check_dns())
   {
     ASSERT_EQ(GEARMAN_GETADDRINFO,
-                 gearman_client_add_servers(&client, "exist.gearman.info:7003,does_not_exist.gearman.info:12345"));
+                 gearman_client_add_servers(&client, "www.google.com:7003,does_not_exist.google.com:12345"));
   }
 
   return TEST_SUCCESS;

--- a/tests/libgearman-1.0/worker_test.cc
+++ b/tests/libgearman-1.0/worker_test.cc
@@ -508,7 +508,7 @@ static test_return_t gearman_worker_add_server_GEARMAN_INVALID_ARGUMENT_TEST(voi
   if (libtest::check_dns())
   {
     ASSERT_EQ(GEARMAN_INVALID_ARGUMENT,
-                 gearman_worker_add_server(NULL, "nonexist.gearman.info", libtest::default_port()));
+                 gearman_worker_add_server(NULL, "does_not_exist.google.com", libtest::default_port()));
   }
 
   return TEST_SUCCESS;
@@ -520,7 +520,7 @@ static test_return_t gearman_worker_add_server_GEARMAN_GETADDRINFO_TEST(void *)
   {
     gearman_worker_st *worker= gearman_worker_create(NULL);
     ASSERT_TRUE(worker);
-    ASSERT_EQ(gearman_worker_add_server(worker, "nonexist.gearman.info", libtest::default_port()), GEARMAN_GETADDRINFO);
+    ASSERT_EQ(gearman_worker_add_server(worker, "does_not_exist.google.com", libtest::default_port()), GEARMAN_GETADDRINFO);
     gearman_worker_free(worker);
   }
 


### PR DESCRIPTION
"make test" and the GitHub CI workflow currently fail because the `gearman.info` website no longer exists. This merge request replaces the tests using the gearman.info domain with google.com. This addresses issue #346.

Is it OK to use google.com? I thought so, but if you have a better replacement....

There's still one test that references `exist.gearman.info`, but it's skipped. I didn't change that one. Let me know if I should. Or maybe just remove this skipped test entirely?

Tag @SpamapS