### PR TITLE
Include missing libboost files in tarball

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -50,6 +50,7 @@ include benchmark/include.am
 include bin/include.am
 include examples/include.am
 include gearmand/include.am
+include libboost/include.am
 include libgearman-server/include.am
 include libgearman/include.am
 include libgearman-1.0/include.am

--- a/libboost/include.am
+++ b/libboost/include.am
@@ -1,0 +1,5 @@
+# vim:ft=automake
+# included from Top Level Makefile.am
+# All paths should be given relative to the root
+
+noinst_HEADERS+= libboost/config/workaround.hpp


### PR DESCRIPTION
It appears when #306 was merged for Mac OS X it broke tarballs but we haven't tried to build a release since then.

Closes #355 