### PR TITLE
Update build files to work with more modern autotools

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -25,7 +25,7 @@ jobs:
           - {name: 'ubtunu-18.04 gcc-8', os: ubuntu-18.04, cc: 'gcc', cxx: 'g++', tag: '8'}
           - {name: 'ubtunu-20.04 gcc-9', os: ubuntu-20.04, cc: 'gcc', cxx: 'g++', tag: '9'}
           - {name: 'ubtunu-20.04 gcc-10', os: ubuntu-20.04, cc: 'gcc', cxx: 'g++', tag: '10'}
-          - {name: 'ubtunu-20.04 gcc-11', os: ubuntu-20.04, cc: 'gcc', cxx: 'g++', tag: '11'}
+          - {name: 'ubtunu-22.04 gcc-11', os: ubuntu-20.04, cc: 'gcc', cxx: 'g++', tag: '11'}
 
     env:
       CC: ${{ matrix.config.cc }}-${{ matrix.config.tag }}

--- a/Makefile.am
+++ b/Makefile.am
@@ -50,6 +50,7 @@ include benchmark/include.am
 include bin/include.am
 include examples/include.am
 include gearmand/include.am
+include libboost/include.am
 include libgearman-server/include.am
 include libgearman/include.am
 include libgearman-1.0/include.am

--- a/benchmark/benchmark.h
+++ b/benchmark/benchmark.h
@@ -46,15 +46,10 @@
 
 #include <libgearman/gearman.h>
 
-#ifdef TIME_WITH_SYS_TIME
-# include <sys/time.h>
+
 # include <time.h>
-#else
 # ifdef HAVE_SYS_TIME_H
 #  include <sys/time.h>
-# else
-#  include <time.h>
-# endif
 #endif
 
 #define GEARMAN_BENCHMARK_DEFAULT_FUNCTION "gb"

--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@
 
 m4_include([version.m4])
 AC_REVISION([m4_esyscmd_s([git describe --always])])
-AC_PREREQ([2.71])
+AC_PREREQ([2.69])
 AC_INIT([gearmand],[VERSION_NUMBER],[https://github.com/gearman/gearmand/issues],[gearmand],[http://gearman.info/])
 
 AC_CONFIG_AUX_DIR([build-aux])
@@ -257,7 +257,7 @@ AX_CHECK_WOLFSSL([have_wolfssl=yes],[have_wolfssl=no])
 AM_CONDITIONAL([ENABLE_WOLFSSL],[test "x${have_wolfssl}" = "xyes"])
 
 AC_DEFUN([AX_ENABLE_SSL],
-         [AC_PREREQ([2.71])dnl
+         [AC_PREREQ([2.69])dnl
          m4_define([_SSL_ENABLE_DEFAULT], [m4_if($1, no, no, no)])dnl
          AC_ARG_ENABLE([ssl],
                        [AS_HELP_STRING([--enable-ssl],

--- a/configure.ac
+++ b/configure.ac
@@ -10,8 +10,8 @@
 
 m4_include([version.m4])
 AC_REVISION([m4_esyscmd_s([git describe --always])])
-AC_PREREQ([2.63])
-AC_INIT([gearmand],VERSION_NUMBER,[https://github.com/gearman/gearmand/issues],[gearmand],[http://gearman.info/])
+AC_PREREQ([2.71])
+AC_INIT([gearmand],[VERSION_NUMBER],[https://github.com/gearman/gearmand/issues],[gearmand],[http://gearman.info/])
 
 AC_CONFIG_AUX_DIR([build-aux])
 
@@ -54,8 +54,7 @@ LT_LIB_M
 
 AC_SUBST([lt_cv_dlopen_libs])
 
-AC_PROG_CC_C99
-AS_IF([test "x${ac_cv_prog_cc_c99}" == "xno"],[AC_MSG_ERROR([No c99 compatible compiler found])])
+# AC_REQUIRE(AC_PROG_CC)
 
 AC_DEFUN([CHECK_CXX0X],[
           AC_LANG_PUSH([C++])
@@ -136,8 +135,6 @@ AX_PROG_SPHINX_BUILD(,[AC_MSG_WARN([sphinx-build version 1.0 or greater is requi
 AX_WITH_PROG([LCOV],[lcov])
 AX_WITH_PROG([LCOV_GENHTML],[genhtml])
 
-# Checks for header files.
-AC_HEADER_STDC
 AC_HEADER_SYS_WAIT
 AC_CHECK_HEADERS_ONCE([arpa/inet.h])
 AC_CHECK_HEADERS_ONCE([errno.h])
@@ -191,7 +188,8 @@ AC_C_CONST
 AC_C_INLINE
 AC_C_VOLATILE
 AC_HEADER_STDBOOL
-AC_HEADER_TIME
+AC_CHECK_HEADERS_ONCE([sys/time.h])
+
 AC_TYPE_INT32_T
 AC_TYPE_INT64_T
 AC_TYPE_OFF_T
@@ -259,7 +257,7 @@ AX_CHECK_WOLFSSL([have_wolfssl=yes],[have_wolfssl=no])
 AM_CONDITIONAL([ENABLE_WOLFSSL],[test "x${have_wolfssl}" = "xyes"])
 
 AC_DEFUN([AX_ENABLE_SSL],
-         [AC_PREREQ([2.63])dnl
+         [AC_PREREQ([2.71])dnl
          m4_define([_SSL_ENABLE_DEFAULT], [m4_if($1, no, no, no)])dnl
          AC_ARG_ENABLE([ssl],
                        [AS_HELP_STRING([--enable-ssl],

--- a/gearmand/gearmand.cc
+++ b/gearmand/gearmand.cc
@@ -54,15 +54,9 @@
 #include <unistd.h>
 #include <grp.h>
 
-#ifdef TIME_WITH_SYS_TIME
-# include <sys/time.h>
-# include <time.h>
-#else
-# ifdef HAVE_SYS_TIME_H
-#  include <sys/time.h>
-# else
-#  include <time.h>
-# endif
+#include <time.h>
+#ifdef HAVE_SYS_TIME_H
+#include <sys/time.h>
 #endif
 
 #include "libgearman-server/gearmand.h"

--- a/gearmand/server_common.h
+++ b/gearmand/server_common.h
@@ -41,15 +41,9 @@
 #include <signal.h>
 #endif
 
-#ifdef TIME_WITH_SYS_TIME
-# include <sys/time.h>
-# include <time.h>
-#else
-# ifdef HAVE_SYS_TIME_H
-#  include <sys/time.h>
-# else
-#  include <time.h>
-# endif
+#include <time.h>
+#ifdef HAVE_SYS_TIME_H
+#include <sys/time.h>
 #endif
 
 #ifdef HAVE_EVENT_H

--- a/libboost/include.am
+++ b/libboost/include.am
@@ -1,0 +1,5 @@
+# vim:ft=automake
+# included from Top Level Makefile.am
+# All paths should be given relative to the root
+
+noinst_HEADERS+= libboost/config/workaround.hpp

--- a/libgearman-server/common.h
+++ b/libgearman-server/common.h
@@ -73,15 +73,9 @@
 # include <unistd.h>
 #endif
 
-#ifdef TIME_WITH_SYS_TIME
-# include <sys/time.h>
-# include <time.h>
-#else
-# ifdef HAVE_SYS_TIME_H
+#include <time.h>
+#ifdef HAVE_SYS_TIME_H
 #  include <sys/time.h>
-# else
-#  include <time.h>
-# endif
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
This also enables a build target on Ubuntu 22.04 with the latest gcc version.

Tested to still work at least as far back as Ubuntu 16.04.

Closes #351 