### PR TITLE
Silence implicit fallthrough warning on newer GCC versions

### DIFF
--- a/libgearman-server/plugins/protocol/http/protocol.cc
+++ b/libgearman-server/plugins/protocol/http/protocol.cc
@@ -62,8 +62,17 @@
  */
 #define GEARMAND_PROTOCOL_HTTP_DEFAULT_PORT "8080"
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wold-style-cast"
+#pragma clang diagnostic ignored "-Wimplicit-fallthrough"
+#elif defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
+#if __GNUC__ >= 7
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#endif /* __GNUC__ >= 7 */
+#endif
 
 class HTTPtext;
 
@@ -684,4 +693,8 @@ gearmand_error_t HTTP::start(gearmand_st *gearmand)
 } // namespace gearmand
 
 /** @} */
+#ifdef __clang__
+#pragma clang diagnostic pop
+#elif defined(__GNUC_)
 #pragma GCC diagnostic pop
+#endif


### PR DESCRIPTION
In my testing on Alpine 3.13 (which has gcc 10.2.1) and 3.17 (which has gcc 12.2.1), the following warning was printed during the builds:
```
  CXX      libgearman-server/plugins/protocol/http/libgearman_server_la-protocol.lo
libgearman-server/plugins/protocol/http/protocol.cc: In member function 'virtual size_t HTTPtext::pack(const gearmand_packet_st*, gearman_server_con_st*, void*, size_t, gearmand_error_t&)':
libgearman-server/plugins/protocol/http/protocol.cc:153:25: warning: this statement may fall through [-Wimplicit-fallthrough=]
  153 |       gearmand_log_debug(GEARMAN_DEFAULT_LOG_PARAM,
      |       ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
  154 |                          "Bad packet command: gearmand_command_t:%s",
      |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  155 |                          gearman_strcommand(packet->command));
      |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
libgearman-server/plugins/protocol/http/protocol.cc:157:5: note: here
  157 |     case GEARMAN_COMMAND_WORK_FAIL:
      |     ^~~~
```
This pull request address this by ignoring `-Wimplicit-fallthrough` in `libgearman-server/plugins/protocol/http/protocol.cc`.

I used a variation on the Dockerfile in [this comment](https://github.com/gearman/gearmand/pull/358#issuecomment-1320985781) with the modified `server.cc` file to test these changes.