### PR TITLE
Updated actions/checkout to v3 in GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -65,7 +65,7 @@ jobs:
           sudo apt-add-repository ${{ matrix.config.toolchain }}
           sudo apt-get update
           sudo apt-get -y install libtool
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: tweak multi_client_test.cc for container usage
       if: matrix.config.container == 'ubuntu:14.04'
       run: |


### PR DESCRIPTION
This trivial pull request partially addresses issue #354. It eliminates the following warnings currently emitted by the GitHub Actions CI workflow:

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2

All it does is change `uses: actions/checkout@v2` to `uses: actions/checkout@v3`.