### PR TITLE
Added CXXFLAGS="-Wp,-D_GLIBCXX_ASSERTIONS" to gcc-9 and higher builds in GitHub Actions CI

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -31,6 +31,7 @@ jobs:
       CC: ${{ matrix.config.cc }}-${{ matrix.config.tag }}
       CXX: ${{ matrix.config.cxx }}-${{ matrix.config.tag }}
       GHA_CONTAINER: ${{ matrix.config.container }}
+      CCVERSION: ${{ matrix.config.tag }}
 
     steps:
     - name: if running in a container, update and install sudo, git, and other basics
@@ -91,9 +92,21 @@ jobs:
            fi
            ./bootstrap.sh -a
     - name: configure
-      run: ./configure --enable-ssl
+      run: |
+           if [[ "${CC}" == gcc* ]] && [ "${CCVERSION}" -ge 9 ]; then
+              CXXFLAGS="-Wp,-D_GLIBCXX_ASSERTIONS"
+              export CXXFLAGS
+              echo "CXXFLAGS: $CXXFLAGS"
+           fi
+           ./configure --enable-ssl
     - name: make
-      run: ${CC} --version && make
+      run: |
+           if [[ "${CC}" == gcc* ]] && [ "${CCVERSION}" -ge 9 ]; then
+              CXXFLAGS="-Wp,-D_GLIBCXX_ASSERTIONS"
+              export CXXFLAGS
+              echo "CXXFLAGS: $CXXFLAGS"
+           fi
+           ${CC} --version && make
     - name: make test
       run: ${CC} --version && make test
     - name: check test-suite.log


### PR DESCRIPTION
This pull request partially addresses issue #354 by restoring `CXXFLAGS="-Wp,-D_GLIBCXX_ASSERTIONS"` to the gcc-9 and higher builds in GitHub Actions CI. This was previously in the Travis CI, but I forgot to include it in the transition to GitHub Action CI. The gcc documentation says that it "enables extra error checking in the form of precondition assertions, such as bounds checking in strings and null pointer checks when dereferencing smart pointers." This was useful in finding multiple errors in the gearmand source code in the past.