### PR TITLE
Adjust linking order of `libmemcached{,util}`

### DIFF
--- a/m4/ax_libmemcached.m4
+++ b/m4/ax_libmemcached.m4
@@ -126,7 +126,7 @@ AC_DEFUN([_ENABLE_LIBMEMCACHED], [
                LIBMEMCACHED_LIB="-lmemcached"
                AC_SUBST([LIBMEMCACHED_LIB])
                AS_IF([test "x$ax_cv_libmemcached_util" = "xyes"], [
-                     LIBMEMCACHED_UTIL_LIB="-lmemcached -lmemcachedutil"
+                     LIBMEMCACHED_UTIL_LIB="-lmemcachedutil -lmemcached"
                      AC_SUBST([LIBMEMCACHED_UTIL_LIB])
                      ])
                ],[


### PR DESCRIPTION
`libmemcachedutil` depends on `libmemcached`, and as such it should be
specified first in the command-line when linking.  Not doing so can
result in build failures in certain scenarios.

Ref.: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1031450