### PR TITLE
skip removing entries from sqlite if store-queue-on-shutdown is used

### DIFF
--- a/libgearman-server/plugins/base.h
+++ b/libgearman-server/plugins/base.h
@@ -147,6 +147,11 @@ public:
     _store_on_shutdown= store_on_shutdown_;
   }
 
+  bool is_store_on_shutdown()
+  {
+    return _store_on_shutdown;
+  }
+
   bool has_error()
   {
     return _error_string.size();

--- a/libgearman-server/plugins/queue/sqlite/queue.cc
+++ b/libgearman-server/plugins/queue/sqlite/queue.cc
@@ -77,7 +77,7 @@ Sqlite::Sqlite() :
 {
   command_line_options().add_options()
     ("libsqlite3-db", boost::program_options::value(&schema), "Database file to use.")
-    ("store-queue-on-shutdown", boost::program_options::bool_switch(&_store_on_shutdown)->default_value(false), "Store queue on shutdown.")
+    ("store-queue-on-shutdown", boost::program_options::bool_switch(&_store_on_shutdown)->default_value(false), "Store queue on shutdown only.")
     ("libsqlite3-table", boost::program_options::value(&table)->default_value(GEARMAND_QUEUE_SQLITE_DEFAULT_TABLE), "Table to use.")
     ;
 }


### PR DESCRIPTION
if `--store-queue-on-shutdown` is used, database should only be accessed during shutdown and on initial startup. Skipping the done() saves the unnecessary query preparation, database locks, etc...

 - fixes #369