### PR TITLE
Change CI to test Ubuntu 18.04 in containers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,25 +48,31 @@ jobs:
                  ;;
            esac
     - name: override DNS to fix IP address for hostname in some Docker containers
-      if: matrix.config.container == 'ubuntu:14.04'
+      if: matrix.config.container != ''
       run: |
-           echo "==="
-           echo "Before: /etc/hosts"
-           cat /etc/hosts
-           echo "==="
-           echo "Removing localhost name from ::1 entry in /etc/hosts..."
-           sed 's/^::1\s\s*localhost\s\(.*\)/::1 \1/' /etc/hosts > /tmp/hosts.temp
-           cp /tmp/hosts.temp /etc/hosts
-           rm /tmp/hosts.temp
-           echo "After: /etc/hosts"
-           cat /etc/hosts
-           echo "==="
-           ip addr
-           echo "==="
-           echo "'hostname -i' shows '$(hostname -i)'"
-           echo "'hostname -I' shows '$(hostname -I)'"
-           echo "'hostname -s' shows '$(hostname -s)'"
-           echo "'hostname -f' shows '$(hostname -f)'"
+           case "${GHA_CONTAINER}" in
+              ubuntu*)
+                 echo "==="
+                 echo "Before: /etc/hosts"
+                 cat /etc/hosts
+                 echo "==="
+                 echo "Removing localhost name from ::1 entry in /etc/hosts..."
+                 sed 's/^::1\s\s*localhost\s\(.*\)/::1 \1/' /etc/hosts > /tmp/hosts.temp
+                 cp /tmp/hosts.temp /etc/hosts
+                 rm /tmp/hosts.temp
+                 echo "After: /etc/hosts"
+                 cat /etc/hosts
+                 echo "==="
+                 ip addr
+                 echo "==="
+                 echo "'hostname -i' shows '$(hostname -i)'"
+                 echo "'hostname -I' shows '$(hostname -I)'"
+                 echo "'hostname -s' shows '$(hostname -s)'"
+                 echo "'hostname -f' shows '$(hostname -f)'"
+                 ;;
+              *)
+                 ;;
+           esac
     - name: configure toolchain (optional)
       if: matrix.config.toolchain != ''
       run: |
@@ -79,17 +85,23 @@ jobs:
       run: |
            chown -R $(id -u):$(id -g) .
     - name: tweak multi_client_test.cc for container usage
-      if: matrix.config.container == 'ubuntu:14.04'
+      if: matrix.config.container != ''
       run: |
-           echo "==="
-           echo "Before multi_client_test.cc:"
-           grep push_port tests/libgearman-1.0/multi_client_test.cc
-           echo "Changing multi_client_test.cc..."
-           sed -i -e '0,/test->push_port.*libtest/ s/\(test.*push_port(\).*libtest.*\();\)/\1 19298 \2/' tests/libgearman-1.0/multi_client_test.cc
-           sed -i -e '0,/test->push_port.*libtest/ s/\(test.*push_port(\).*libtest.*\();\)/\1 19300 \2/' tests/libgearman-1.0/multi_client_test.cc
-           echo "After multi_client_test.cc:"
-           grep push_port tests/libgearman-1.0/multi_client_test.cc
-           echo "==="
+           case "${GHA_CONTAINER}" in
+              ubuntu*)
+                 echo "==="
+                 echo "Before multi_client_test.cc:"
+                 grep push_port tests/libgearman-1.0/multi_client_test.cc
+                 echo "Changing multi_client_test.cc..."
+                 sed -i -e '0,/test->push_port.*libtest/ s/\(test.*push_port(\).*libtest.*\();\)/\1 19298 \2/' tests/libgearman-1.0/multi_client_test.cc
+                 sed -i -e '0,/test->push_port.*libtest/ s/\(test.*push_port(\).*libtest.*\();\)/\1 19300 \2/' tests/libgearman-1.0/multi_client_test.cc
+                 echo "After multi_client_test.cc:"
+                 grep push_port tests/libgearman-1.0/multi_client_test.cc
+                 echo "==="
+                 ;;
+              *)
+                 ;;
+           esac
     - name: install dependencies
       run: |
            case "${GHA_CONFIG_NAME}" in

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
         config:
           - {name: 'ubuntu-14.04 gcc-4.8', os: ubuntu-latest, container: 'ubuntu:14.04', cc: 'gcc-4.8', cxx: 'g++-4.8', tag: '4.8', toolchain: 'ppa:ubuntu-toolchain-r/test'}
           - {name: 'ubuntu-14.04 gcc-4.9', os: ubuntu-latest, container: 'ubuntu:14.04', cc: 'gcc-4.9', cxx: 'g++-4.9', tag: '4.9', toolchain: 'ppa:ubuntu-toolchain-r/test'}
-          - {name: 'ubuntu-18.04 gcc-5', os: ubuntu-18.04, cc: 'gcc-5', cxx: 'g++-5', tag: '5'}
-          - {name: 'ubuntu-18.04 gcc-6', os: ubuntu-18.04, cc: 'gcc-6', cxx: 'g++-6', tag: '6'}
-          - {name: 'ubuntu-18.04 gcc-7', os: ubuntu-18.04, cc: 'gcc-7', cxx: 'g++-7', tag: '7'}
-          - {name: 'ubuntu-18.04 gcc-8', os: ubuntu-18.04, cc: 'gcc-8', cxx: 'g++-8', tag: '8'}
+          - {name: 'ubuntu-18.04 gcc-5', os: ubuntu-latest, container: 'ubuntu:18.04', cc: 'gcc-5', cxx: 'g++-5', tag: '5'}
+          - {name: 'ubuntu-18.04 gcc-6', os: ubuntu-latest, container: 'ubuntu:18.04', cc: 'gcc-6', cxx: 'g++-6', tag: '6'}
+          - {name: 'ubuntu-18.04 gcc-7', os: ubuntu-latest, container: 'ubuntu:18.04', cc: 'gcc-7', cxx: 'g++-7', tag: '7'}
+          - {name: 'ubuntu-18.04 gcc-8', os: ubuntu-latest, container: 'ubuntu:18.04', cc: 'gcc-8', cxx: 'g++-8', tag: '8'}
           - {name: 'ubuntu-20.04 gcc-9', os: ubuntu-20.04, cc: 'gcc-9', cxx: 'g++-9', tag: '9'}
           - {name: 'ubuntu-20.04 gcc-10', os: ubuntu-20.04, cc: 'gcc-10', cxx: 'g++-10', tag: '10'}
           - {name: 'ubuntu-22.04 gcc-11', os: ubuntu-20.04, cc: 'gcc-11', cxx: 'g++-11', tag: '11'}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       run: |
            case "${GHA_CONTAINER}" in
               ubuntu*)
-                 apt-get -o Acquire::Retries=3 update && DEBIAN_FRONTEND=noninteractive apt-get -o Acquire::Retries=3 -y install tzdata sudo apt-transport-https make apt-file software-properties-common libssl-dev build-essential autotools-dev autoconf automake pkgconf
+                 apt-get -o Acquire::Retries=3 update && DEBIAN_FRONTEND=noninteractive apt-get -o Acquire::Retries=3 -y install tzdata sudo apt-transport-https make apt-file software-properties-common libssl-dev build-essential autotools-dev autoconf automake pkgconf iproute2
                  sudo apt-add-repository ppa:git-core/ppa
                  sudo apt-get -o Acquire::Retries=3 update && apt-get -o Acquire::Retries=3 -y install git
                  ;;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,7 @@ jobs:
               echo "CXXFLAGS: $CXXFLAGS"
            fi
            ./configure --enable-ssl
+      shell: bash
     - name: make
       run: |
            if [[ "${CC}" == gcc* ]] && [ "${CCVERSION}" -ge 9 ]; then
@@ -124,6 +125,7 @@ jobs:
               echo "CXXFLAGS: $CXXFLAGS"
            fi
            ${CC} --version && make
+      shell: bash
     - name: make test
       run: ${CC} --version && make test
     - name: check test-suite.log


### PR DESCRIPTION
Because [GitHub has deprecated the Ubuntu-18.04 workers](https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/), the gearmand CI jobs which run on Ubuntu 18.04 need to be migrated to run in containers instead.