### PR TITLE
Issue #376: Fix configure error when gperf is absent

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -125,7 +125,7 @@ AC_CHECK_PROGS([RPMDEV_SETUPTREE],[rpmdev-setuptree])
 AC_CHECK_PROGS([RPM],[rpm])
 AC_PATH_PROG([GPERF],['gperf'],[])
 AS_IF([test -z "$GPERF"],
-      [AC_MSG_ERROR([could not find gperf])]])
+      [AC_MSG_ERROR([Unable to find gperf])])
 AC_PROG_AWK
 AC_PROG_INSTALL
 AC_PROG_LN_S


### PR DESCRIPTION
This PR addresses issue #376 by removing a stray, unbalanced square bracket from the gperf test in `configure.ac`. It also tweaks the error message displayed when gperf is missing to match other similar error messages in `configure.ac`.