### PR TITLE
Remove "redundant null check due to previous dereference" found in CodeQL scan

### DIFF
--- a/libtest/server.cc
+++ b/libtest/server.cc
@@ -172,15 +172,9 @@ bool Server::wait_for_pidfile() const
 
 bool Server::init(const char *argv[])
 {
-  if (argv)
+  for (const char **ptr= argv; ptr && *ptr ; ++ptr)
   {
-    for (const char **ptr= argv; *ptr ; ++ptr)
-    {
-      if (ptr)
-      {
-        add_option(*ptr);
-      }
-    }
+    add_option(*ptr);
   }
 
   return build();


### PR DESCRIPTION
This PR fixes an "issue" reported by the CodeQL scan of the gearmand source code. The null check on [line 179 of libtest/server.cc](https://github.com/gearman/gearmand/blob/8e80a0ded3495496c7037a50eab7fc680c29b2e9/libtest/server.cc#L177-L179) is redundant because it has already been dereferenced on line 177 in the condition of the `for` loop.
![Screen Shot 2023-11-12 at 6 33 05 PM](https://github.com/gearman/gearmand/assets/22986767/ba6b22f6-cf68-48a9-a460-ce7888377917)

I suppose the `if (argv) { ... }` around the `for` loop could also be removed since the new condition of the `for` loop will also test this, but it doesn't do any harm and arguably improves clarity. I'd be willing to remove it though if you think it should be removed, @SpamapS.