### PR TITLE
Fix syntax error in codeql.yml

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,7 +55,7 @@ jobs:
       run: sudo apt-get -o Acquire::Retries=3 -y install tzdata make apt-file software-properties-common libssl-dev build-essential autotools-dev autoconf automake pkgconf libboost-all-dev gperf libevent-dev uuid-dev sphinx-doc sphinx-common libhiredis-dev gcc g++
 
     - name: Build gearmand
-    - run: |
+      run: |
           ./bootstrap.sh -a
           CXXFLAGS="-Wp,-D_GLIBCXX_ASSERTIONS"
           export CXXFLAGS


### PR DESCRIPTION
Sorry, a stray hyphen sneaked in, making the `codeql.yml` syntax invalid and resulting in the error "every step must define a \`uses\` or \`run\` key." Importantly, what this error really means in this case is that every step should only have a single hyphen. My apologies for not catching this before PR #379 was merged.