### PR TITLE
Update GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           - {name: 'ubuntu-18.04 gcc-8', os: ubuntu-latest, container: 'ubuntu:18.04', cc: 'gcc-8', cxx: 'g++-8', tag: '8'}
           - {name: 'ubuntu-20.04 gcc-9', os: ubuntu-20.04, cc: 'gcc-9', cxx: 'g++-9', tag: '9'}
           - {name: 'ubuntu-20.04 gcc-10', os: ubuntu-20.04, cc: 'gcc-10', cxx: 'g++-10', tag: '10'}
-          - {name: 'ubuntu-20.04 gcc-11', os: ubuntu-20.04, cc: 'gcc-11', cxx: 'g++-11', tag: '11'}
+          - {name: 'ubuntu-20.04 gcc-11', os: ubuntu-20.04, cc: 'gcc-11', cxx: 'g++-11', tag: '11', toolchain: 'ppa:ubuntu-toolchain-r/test'}
           - {name: 'ubuntu-22.04 gcc-12', os: ubuntu-22.04, cc: 'gcc-12', cxx: 'g++-12', tag: '12'}
 
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
       CCVERSION: ${{ matrix.config.tag }}
       GHA_CONTAINER: ${{ matrix.config.container }}
       GHA_CONFIG_NAME: ${{ matrix.config.name }}
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     steps:
     - name: if running in a container, update and install sudo, git, and other basics

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
           - {name: 'ubuntu-20.04 gcc-10', os: ubuntu-20.04, cc: 'gcc-10', cxx: 'g++-10', tag: '10'}
           - {name: 'ubuntu-20.04 gcc-11', os: ubuntu-20.04, cc: 'gcc-11', cxx: 'g++-11', tag: '11', toolchain: 'ppa:ubuntu-toolchain-r/test'}
           - {name: 'ubuntu-22.04 gcc-12', os: ubuntu-22.04, cc: 'gcc-12', cxx: 'g++-12', tag: '12'}
+          - {name: 'ubuntu-24.04 gcc-13', os: ubuntu-24.04, cc: 'gcc-13', cxx: 'g++-13', tag: '13'}
 
     env:
       CC: ${{ matrix.config.cc }}


### PR DESCRIPTION
This merge request attempts to fix various failures with the CI workflow.

• It adds `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true` to the environment to workaround issues with older Ubuntu versions. See https://github.com/actions/checkout/issues/1590 for details. This change fixed the older Ubuntu builds in the Docker images. Alas, this is only a temporary fix, supposedly. Not sure what we are going to do when it no longer works.
• It adds the `ppa:ubuntu-toolchain-r/test` toolchain repository for the gcc-11 build. This fixes the "Unable to locate package gcc-11" error that build was experiencing. Refer to the discussion at https://github.com/actions/runner-images/issues/9679.
• Finally, it adds gcc-13 build on Ubuntu 24.04 to the testing matrix.