### PR TITLE
Issue #398: Fix gcc 14 build failure for reversed calloc args

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
           - {name: 'ubuntu-20.04 gcc-11', os: ubuntu-20.04, cc: 'gcc-11', cxx: 'g++-11', tag: '11', toolchain: 'ppa:ubuntu-toolchain-r/test'}
           - {name: 'ubuntu-22.04 gcc-12', os: ubuntu-22.04, cc: 'gcc-12', cxx: 'g++-12', tag: '12'}
           - {name: 'ubuntu-24.04 gcc-13', os: ubuntu-24.04, cc: 'gcc-13', cxx: 'g++-13', tag: '13'}
+          - {name: 'ubuntu-24.04 gcc-14', os: ubuntu-24.04, cc: 'gcc-14', cxx: 'g++-14', tag: '14'}
 
     env:
       CC: ${{ matrix.config.cc }}

--- a/tests/libgearman-1.0/internals.cc
+++ b/tests/libgearman-1.0/internals.cc
@@ -318,7 +318,7 @@ static test_return_t gearman_packet_give_data_test(void *)
   // @note Since this is a give data, ignore any errors that believe there is
   // an implicit memory leak.
   size_t data_size= test_literal_param_size("Mine!");
-  char *data= (char *)calloc(sizeof(char), data_size +1);
+  char *data= (char *)calloc(data_size +1, sizeof(char));
   ASSERT_TRUE(data);
   memcpy(data, "Mine!", data_size);
 
@@ -345,7 +345,7 @@ static test_return_t gearman_packet_take_data_test(void *)
   // Since this is a take data, ignore any errors that believe there is an
   // implicit memory leak.
   size_t data_size= test_literal_param_size("Mine!");
-  char *data= (char *)calloc(sizeof(char), data_size +1);
+  char *data= (char *)calloc(data_size +1, sizeof(char));
   ASSERT_TRUE(data);
   memcpy(data, "Mine!", data_size);
 


### PR DESCRIPTION
This merge request addresses issue #398.

It fixes the reversed `calloc()` arguments in the internals tests that was revealed by building with gcc 14.1 on Ubuntu 24.04.

It also adds a build using gcc-14 on Ubuntu 24.04 to the GitHub Actions CI workflow.