### PR TITLE
supervisord/Dockerfile: install missed tzdata package

### DIFF
--- a/docker/example/supervisord/Dockerfile
+++ b/docker/example/supervisord/Dockerfile
@@ -10,14 +10,14 @@ LABEL version="${version}"
 ENV DEBIAN_FRONTEND=noninteractive \
     TZ=America/New_York \
     HOME=/root
-RUN (echo $TZ > /etc/timezone) \
- && dpkg-reconfigure tzdata
+RUN echo $TZ > /etc/timezone
 
 # Install packages
 RUN apt-get update \
  && apt-get -y upgrade \
  && apt-get -y install \
-	supervisor \
+  supervisor \
+  tzdata \
  && apt-get clean autoclean \
  && apt-get -y autoremove \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Resolves #400

```
$ git log -1 --pretty="%h"
5f1c8887
$ make latest 
Building Docker image gearmand/supervisord:1.0...
docker build  --build-arg version=1.0 -t gearmand/supervisord:1.0 .
[+] Building 1.1s (11/11) FINISHED                                                                                                                                             docker:default
 => [internal] load .dockerignore                                                                                                                                                        0.0s
 => => transferring context: 49B                                                                                                                                                         0.0s
 => [internal] load build definition from Dockerfile                                                                                                                                     0.0s
 => => transferring dockerfile: 1.06kB                                                                                                                                                   0.0s
 => [internal] load metadata for docker.io/library/ubuntu:latest                                                                                                                         1.0s
 => [1/6] FROM docker.io/library/ubuntu:latest@sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30                                                                   0.0s
 => [internal] load build context                                                                                                                                                        0.0s
 => => transferring context: 38B                                                                                                                                                         0.0s
 => CACHED [2/6] RUN (echo America/New_York > /etc/timezone)                                                                                                                             0.0s
 => CACHED [3/6] RUN apt-get update  && apt-get -y upgrade  && apt-get -y install tzdata  && apt-get -y install  supervisor  && apt-get clean autoclean  && apt-get -y autoremove  && r  0.0s
 => CACHED [4/6] RUN mkdir -p /var/log/supervisor  && mkdir -p /var/run/supervisor  && mkdir -p /etc/supervisor/conf.d                                                                   0.0s
 => CACHED [5/6] COPY supervisord.conf /etc/supervisor/supervisord.conf                                                                                                                  0.0s
 => CACHED [6/6] RUN ln -s /etc/supervisor/supervisord.conf /etc/supervisord.conf  && groupadd supervisor  && chgrp supervisor /etc/supervisor/supervisord.conf  && chmod 640 /etc/supe  0.0s
 => exporting to image                                                                                                                                                                   0.0s
 => => exporting layers                                                                                                                                                                  0.0s
 => => writing image sha256:aa5d9c8ade014897e3675f5c37d04b956325344942a865144ba6902b806c7413                                                                                             0.0s
 => => naming to docker.io/gearmand/supervisord:1.0                                                                                                                                      0.0s
(docker images -q -f dangling=true | xargs --no-run-if-empty docker rmi)
Tagging Docker image gearmand/supervisord:1.0 with latest...
docker tag `docker image ls --format '{{.ID}}' gearmand/supervisord:1.0` gearmand/supervisord:latest
(docker images -q -f dangling=true | xargs --no-run-if-empty docker rmi)

```