### PR TITLE
Update Dockerfiles for latest gearmand version and other minor tweaks

### DIFF
--- a/docker/example/gearmand/Dockerfile
+++ b/docker/example/gearmand/Dockerfile
@@ -1,6 +1,6 @@
-FROM gearmand/supervisord:latest
+FROM gearmand/supervisord:1.0
 
-ARG version=1.1.19.1
+ARG version=1.1.21
 
 LABEL description="Gearman Job Server Image"
 LABEL maintainer="Gearmand Developers https://github.com/gearman/gearmand"
@@ -11,17 +11,17 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
  && apt-get -y upgrade \
  && apt-get -y install \
-	make \
-	gcc \
-	g++ \
-	gperf \
-	libboost-all-dev \
-	libevent-dev \
-	libhiredis-dev \
-	libssl-dev \
-	libtokyocabinet-dev \
-	uuid-dev \
-	wget \
+        make \
+        gcc \
+        g++ \
+        gperf \
+        libboost-all-dev \
+        libevent-dev \
+        libhiredis-dev \
+        libssl-dev \
+        libtokyocabinet-dev \
+        uuid-dev \
+        wget \
  && apt-get clean autoclean \
  && apt-get -y autoremove \
  && rm -rf /var/lib/apt/lists/*
@@ -52,11 +52,6 @@ RUN groupadd gearman \
 RUN touch /var/log/gearmand.log \
  && chown gearman:gearman /var/log/gearmand.log
 COPY gearmand.conf /etc/supervisor/conf.d/gearmand.conf
-
-# Links
-RUN ln /usr/sbin/gearmand /sbin/gearmand \
- && ln /usr/bin/gearman /bin/gearman \
- && ln /usr/bin/gearadmin /bin/gearadmin
 
 HEALTHCHECK --interval=5m --timeout=3s --retries=2 \
         CMD test $(supervisorctl status gearmand | awk '{print $2}' | grep 'RUNNING' | wc -l) -eq 1 || exit 1

--- a/docker/example/gearmand/Makefile
+++ b/docker/example/gearmand/Makefile
@@ -1,5 +1,5 @@
 IMAGE_NAME = gearmand
-IMAGE_VERSION = 1.1.19.1
+IMAGE_VERSION = 1.1.21
 USE_CACHE ?=
 
 image:

--- a/docker/example/gearmand/gearmand.conf
+++ b/docker/example/gearmand/gearmand.conf
@@ -1,8 +1,8 @@
 [program:gearmand]
 user = gearman
 priority = 100
-###command = /sbin/gearmand --port 4730 --ssl --ssl-ca-file /var/lib/gearman/gearmand-ca.pem --ssl-certificate /var/lib/gearman/gearmand.pem --ssl-key /var/lib/gearman/gearmand.key --verbose INFO -l /var/log/gearmand.log
-command = /sbin/gearmand --port 4730 --verbose INFO -l /var/log/gearman.log
+###command = /usr/sbin/gearmand --port 4730 --ssl --ssl-ca-file /var/lib/gearman/gearmand-ca.pem --ssl-certificate /var/lib/gearman/gearmand.pem --ssl-key /var/lib/gearman/gearmand.key --verbose INFO -l /var/log/gearmand.log
+command = /usr/sbin/gearmand --port 4730 --verbose INFO -l /var/log/gearman.log
 redirect_stderr = true
 stdout_logfile = /var/log/supervisor/gearman.log
 stdout_logfile_maxbytes = 50MB

--- a/docker/example/supervisord/Dockerfile
+++ b/docker/example/supervisord/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:latest
 
 ARG version=1.0
+ARG timezone=America/New_York
 
 LABEL description="Supervisord Base Image for Gearmand"
 LABEL maintainer="Gearmand Developers https://github.com/gearman/gearmand" 
@@ -8,7 +9,7 @@ LABEL version="${version}"
 
 # Configure timezone
 ENV DEBIAN_FRONTEND=noninteractive \
-    TZ=America/New_York \
+    TZ=${timezone} \
     HOME=/root
 RUN echo $TZ > /etc/timezone
 
@@ -16,8 +17,8 @@ RUN echo $TZ > /etc/timezone
 RUN apt-get update \
  && apt-get -y upgrade \
  && apt-get -y install \
-  supervisor \
-  tzdata \
+        supervisor \
+        tzdata \
  && apt-get clean autoclean \
  && apt-get -y autoremove \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This merge request

• bumps the gearmand version number to the latest released version,
• detabifies the Dockerfiles,
• removes the symbolic links previously added to the gearmand image since the `ln` command doesn't work (and isn't needed) on Ubuntu 24.04, and
• changes the timezone used in the images into a Docker image build argument.