### PR TITLE
Fix CodeQL gripes with usage of c_str() pointers after the lifetime of their associated std::string objects

### DIFF
--- a/libtest/signal.cc
+++ b/libtest/signal.cc
@@ -244,8 +244,8 @@ bool SignalThread::setup()
 {
   set_shutdown(SHUTDOWN_RUNNING);
 
-  const char * lock_name = random_lock_name().c_str();
-  lock = sem_open(lock_name, O_CREAT|O_EXCL, S_IRUSR|S_IWUSR, 0);
+  std::string lock_name = random_lock_name();
+  lock = sem_open(lock_name.c_str(), O_CREAT|O_EXCL, S_IRUSR|S_IWUSR, 0);
   if (lock == SEM_FAILED)
   {
     Error << errno << ": " << strerror(errno)

--- a/util/signal.cc
+++ b/util/signal.cc
@@ -246,8 +246,8 @@ bool SignalThread::setup()
     return false;
   }
 
-  const char * lock_name = random_lock_name().c_str();
-  lock = sem_open(lock_name, O_CREAT|O_EXCL, S_IRUSR|S_IWUSR, 0);
+  std::string lock_name = random_lock_name();
+  lock = sem_open(lock_name.c_str(), O_CREAT|O_EXCL, S_IRUSR|S_IWUSR, 0);
   if (lock == SEM_FAILED) {
     std::cerr << "WARNING: sem_open failed(" << strerror(errno) << ")"
               << " when opening lock '" << lock_name << "'." << std::endl;


### PR DESCRIPTION
This merge request rectifies the CodeQL gripes concerning the usage of `c_str()` pointers after the lifetime of their associated `std::string` objects.

https://github.com/gearman/gearmand/security/code-scanning/39
https://github.com/gearman/gearmand/security/code-scanning/40