### PR TITLE
Fix CodeQL gripe with incorrect return value check for sscanf() call

### DIFF
--- a/libgearman-server/plugins/queue/redis/queue.cc
+++ b/libgearman-server/plugins/queue/redis/queue.cc
@@ -423,7 +423,7 @@ static gearmand_error_t _hiredis_replay(gearman_server_st *server, void *context
                     unique);
 
     free(prefix);
-    if (ret == 0)
+    if (ret != 3)
     {
       continue;
     }


### PR DESCRIPTION
This merge request rectifies a CodeQL gripe with an incorrect return value check for a `sscanf()` call:

https://github.com/gearman/gearmand/security/code-scanning/41

I don't actually use Hiredis, so this change is completely untested. I think it's right though. Does it look correct to you, @SpamapS ?