### PR TITLE
Issue #407: Make bootstrap compatible with autoconf 2.72

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
           - {name: 'ubuntu-24.04 gcc-13', os: ubuntu-24.04, cc: 'gcc-13', cxx: 'g++-13', tag: '13'}
           - {name: 'ubuntu-24.04 gcc-14', os: ubuntu-24.04, cc: 'gcc-14', cxx: 'g++-14', tag: '14'}
           - {name: 'alpine-3.18 gcc-12', os: ubuntu-latest, container: 'alpine:3.18', cc: 'gcc', cxx: 'g++', tag: '12'}
+          - {name: 'alpine-3.20 gcc-13', os: ubuntu-latest, container: 'alpine:3.20', cc: 'gcc', cxx: 'g++', tag: '13'}
 
     env:
       CC: ${{ matrix.config.cc }}

--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@
 # Use and distribution licensed under the BSD license.  See
 # the COPYING file in this directory for full text.
 
-m4_include([version.m4])
+m4_include([./version.m4])
 AC_REVISION([m4_esyscmd_s([git describe --always])])
 AC_PREREQ([2.69])
 AC_INIT([gearmand],[VERSION_NUMBER],[https://github.com/gearman/gearmand/issues],[gearmand],[http://gearman.info/])


### PR DESCRIPTION
This merge request addresses issue #407 by modifying `configure.ac` so that it is compatible with autoconf 2.72.