### PR TITLE
Add Alpine 3.19 build to GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
           - {name: 'ubuntu-24.04 gcc-13', os: ubuntu-24.04, cc: 'gcc-13', cxx: 'g++-13', tag: '13'}
           - {name: 'ubuntu-24.04 gcc-14', os: ubuntu-24.04, cc: 'gcc-14', cxx: 'g++-14', tag: '14'}
           - {name: 'alpine-3.18 gcc-12', os: ubuntu-latest, container: 'alpine:3.18', cc: 'gcc', cxx: 'g++', tag: '12'}
+          - {name: 'alpine-3.19 gcc-13', os: ubuntu-latest, container: 'alpine:3.19', cc: 'gcc', cxx: 'g++', tag: '13'}
           - {name: 'alpine-3.20 gcc-13', os: ubuntu-latest, container: 'alpine:3.20', cc: 'gcc', cxx: 'g++', tag: '13'}
 
     env:


### PR DESCRIPTION
This merge request adds an Alpine 3.19 build to the GitHub Actions CI.

A previous attempt at this resulted in a segmentation fault during a test; however, I suspect that might have been fixed by PR #404, so let's try again.