### PR TITLE
Address CodeQL gripe about uncontrolled format string in handling of GEARMAND_PORT

### DIFF
--- a/libgearman-server/log.cc
+++ b/libgearman-server/log.cc
@@ -504,7 +504,7 @@ gearmand_error_t gearmand_log_gai_error(const char *position, const char *functi
 {
   if (rc == EAI_SYSTEM)
   {
-    return gearmand_log_perror(position, function, errno, message);
+    return gearmand_log_perror(position, function, errno, "%s", message);
   }
 
   gearmand_log_error(position, function, "%s getaddrinfo(%s)", message, gai_strerror(rc));


### PR DESCRIPTION
This merge request addresses CodeQL's gripe about an "[uncontrolled format string](https://github.com/gearman/gearmand/security/code-scanning/47)" alert around line 626 of `libgearman-server/gearmand.cc`. The alert suggests that, if a user sets the `GEARMAND_PORT` environment variable to a string with percent characters in it, for example, it could result in a buffer overflow and/or crash the program. (Refer to meta-issue #406.) ~~This merge request addresses that by limiting the string to at most 5 characters (since 65535 is the maximum port number) and then truncating the string at the first non-digit character.~~

~~I believe this PR also addresses issue #320 with Kubernetes setting `GEARMAND_PORT` to unexpected values by default.~~