### PR TITLE
Issue #373: Fix sphinx-build warnings and errors when using new versions of Sphinx

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,9 @@ jobs:
     steps:
     - name: Install Dependencies
       run: |
-        sudo apt update && sudo apt install -y \
+        apt-get -o Acquire::Retries=3 update && \
+        env DEBIAN_FRONTEND=noninteractive \
+        apt-get -o Acquire::Retries=3 install -y \
           apt-transport-https \
           apt-file \
           software-properties-common \
@@ -40,6 +42,7 @@ jobs:
           autotools-dev \
           autoconf \
           automake \
+          git \
           make \
           pkgconf \
           libboost-all-dev \

--- a/docs/source/conf.py.in
+++ b/docs/source/conf.py.in
@@ -95,6 +95,8 @@ pygments_style = 'colorful'
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []
 
+# Added so that Sphinx's C domain will treat 'bool' as a type name.
+c_extra_keywords = []
 
 # -- Options for HTML output ---------------------------------------------------
 

--- a/docs/source/libgearman.rst
+++ b/docs/source/libgearman.rst
@@ -60,7 +60,7 @@ A number of constants have been provided for in the library.
  
 The default port used by gearmand(3).
 
-.. c:macro:: GEARMAN_DEFAULT_TCP_PORT
+.. c:macro:: GEARMAN_DEFAULT_TCP_SERVICE
  
 The default service used by gearmand(3).
 

--- a/docs/source/libgearman/gearman_return_t.rst
+++ b/docs/source/libgearman/gearman_return_t.rst
@@ -39,7 +39,7 @@ occurred. This should be used for testing loops.
 Possible values of :c:type:`gearman_return_t`:
 ++++++++++++++++++++++++++++++++++++++++++++++
 
-.. c:type:: GEARMAN_SUCCESS
+.. c:type:`GEARMAN_SUCCESS`
 
   Success
 
@@ -185,7 +185,7 @@ value as return values to the calling client.
 
    Worker has sent an exception the client via :c:func:`gearman_job_send_exception`
 
-.. c:type:: GEARMAN_WORK_FAIL  
+.. c:type:`GEARMAN_WORK_FAIL`
 
    A task has failed, and the worker has exited with an error or it called :c:func:`gearman_job_send_fail`
 
@@ -203,7 +203,7 @@ WORKER TO CLIENT
 
 Any function defined by :c:func:`gearman_worker_define_function` may, and can only, return the following :c:type:`gearman_return_t` values.
 
-.. c:type:: GEARMAN_SUCCESS 
+.. c:type:`GEARMAN_SUCCESS`
 
    The function successfully completed the job.
 

--- a/docs/source/libgearman/gearman_string_t.rst
+++ b/docs/source/libgearman/gearman_string_t.rst
@@ -10,11 +10,15 @@ SYNOPSIS
 
 .. c:type:: gearman_string_t
 
-.. c:macro:: size_t gearman_size(gearman_string_t)
+.. c:macro:: gearman_size(string)
 
-.. c:macro:: const char *gearman_c_str(gearman_string_t)
+   Returns the size of the string.
 
-Compile and link with -lgearman
+.. c:macro:: gearman_c_str(string)
+
+   Returns the C string representation.
+
+Compile and link with -lgearman.
 
 -----------
 DESCRIPTION

--- a/docs/source/libgearman/types.rst
+++ b/docs/source/libgearman/types.rst
@@ -2,7 +2,7 @@
 Required C types
 ================
 
-.. highlightlang:: c
+.. highlight:: c
 
 Types
 -----
@@ -24,6 +24,6 @@ C Types Used
 
 .. c:type:: time_t
 
-.. c:type:: struct timespec
+.. c:type:: timespec
 
 .. c:type:: sasl_callback_t


### PR DESCRIPTION
This PR addresses issue #373 by fixing a number of warnings and errors emitted by recent versions of Sphinx when building the HTML documentation for gearmand.

It has been successfully tested with Sphinx 7.2.6 on Ubuntu 24.04 and with Sphinx 1.8.5 on Ubuntu 20.04.