### PR TITLE
Add sudo back to the GitHub Actions workflow docs.yml

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,9 +32,9 @@ jobs:
     steps:
     - name: Install Dependencies
       run: |
-        apt-get -o Acquire::Retries=3 update && \
+        sudo apt-get -o Acquire::Retries=3 update && \
         env DEBIAN_FRONTEND=noninteractive \
-        apt-get -o Acquire::Retries=3 install -y \
+        sudo apt-get -o Acquire::Retries=3 install -y \
           apt-transport-https \
           apt-file \
           software-properties-common \


### PR DESCRIPTION
:sigh: I tested every command in the workflow in Docker containers, but I was root in these containers and, apparently, the docs.yml workflow isn't running as root and needs to use sudo to install the dependencies. This PR fixes that.