### PR TITLE
Prepare example Dockerfile for release of version 1.1.22

### DIFF
--- a/docker/example/gearmand/Dockerfile
+++ b/docker/example/gearmand/Dockerfile
@@ -1,6 +1,6 @@
 FROM gearmand/supervisord:1.0
 
-ARG version=1.1.21
+ARG version=1.1.22
 
 LABEL description="Gearman Job Server Image"
 LABEL maintainer="Gearmand Developers https://github.com/gearman/gearmand"

--- a/docker/example/gearmand/Makefile
+++ b/docker/example/gearmand/Makefile
@@ -1,5 +1,5 @@
 IMAGE_NAME = gearmand
-IMAGE_VERSION = 1.1.21
+IMAGE_VERSION = 1.1.22
 USE_CACHE ?=
 
 image:


### PR DESCRIPTION
This PR updates the gearmand version number in the example Docker and its support Makefile.