### PR TITLE
Issue #438: Fix dist-rpm builds on recent Fedora

### DIFF
--- a/docker/testing/fedora/43/.dockerignore
+++ b/docker/testing/fedora/43/.dockerignore
@@ -1,0 +1,1 @@
+Makefile

--- a/docker/testing/fedora/43/Dockerfile
+++ b/docker/testing/fedora/43/Dockerfile
@@ -1,0 +1,63 @@
+ARG version=43
+FROM fedora:${version}
+
+ARG version
+ARG GEARMAN_REPO=https://github.com/gearman/gearmand
+ARG GEARMAN_REPO_BRANCH=master
+
+LABEL description="Gearman Job Server Image (Fedora ${version})"
+LABEL maintainer="Gearmand Developers ${GEARMAN_REPO}"
+LABEL version="${GEARMAN_REPO}/tree/${GEARMAN_REPO_BRANCH} Fedora ${version}"
+
+# Install packages
+RUN dnf makecache \
+ && dnf update -y \
+ && dnf install -y \
+	rpm-build \
+	git \
+	libtool \
+	autoconf \
+	automake \
+	bison \
+	make \
+	gettext-devel \
+	boost-devel \
+	boost-thread \
+	chrpath \
+	gcc-c++ \
+	gperf \
+	gperftools-devel \
+	hiredis-devel \
+	libevent-devel \
+	libmemcached-devel \
+	libpq-devel \
+	libuuid-devel \
+	mariadb-connector-c-devel \
+	memcached \
+	openssl-devel \
+	sqlite-devel \
+	tokyocabinet-devel \
+	zlib-devel \
+	python3-sphinx \
+ && dnf clean all \
+ && rm -rf /var/cache/yum
+
+# Add user and set up rpmbuild directory
+RUN adduser -m --shell /bin/bash gearman \
+ && mkdir -p /home/gearman/rpmbuild/SOURCES \
+ && chown -R gearman:gearman /home/gearman/rpmbuild
+
+# Switch to gearman user
+USER gearman
+
+# Clone the GitHub repository master branch
+RUN cd /home/gearman && git clone --depth 1 --branch ${GEARMAN_REPO_BRANCH} ${GEARMAN_REPO}.git
+
+# Bootstrap, configure, make, and make test
+WORKDIR /home/gearman/gearmand
+RUN ./bootstrap.sh -a
+RUN ./configure --enable-ssl 2>&1 | tee ./configure.log
+RUN make 2>&1 | tee ./build.log
+RUN make test 2>&1 | tee ./test.log
+RUN make dist 2>&1 | tee ./dist.log
+RUN make dist-rpm 2>&1 | tee ./rpmbuild.log

--- a/docker/testing/fedora/43/Makefile
+++ b/docker/testing/fedora/43/Makefile
@@ -1,0 +1,12 @@
+IMAGE_NAME = gearmand-testing
+IMAGE_BASE = fedora
+IMAGE_VERSION = 43
+IMAGE_TAG = $(IMAGE_NAME)/${IMAGE_BASE}:$(IMAGE_VERSION)
+USE_CACHE ?=
+
+image:
+	@echo "Building Docker image ${IMAGE_TAG}..."
+	-docker build $(USE_CACHE) --network=host -t $(IMAGE_TAG) . && (docker images -q -f dangling=true | xargs --no-run-if-empty docker rmi)
+
+image-no-cache:
+	$(MAKE) -e USE_CACHE=--no-cache

--- a/support/gearmand.spec.in
+++ b/support/gearmand.spec.in
@@ -8,7 +8,8 @@ BuildRequires: bison
 URL: https://github.com/gearman/gearmand
 Requires: sqlite, libevent >= 1.4, boost-program-options >=  1.39
 
-Packager: Brian Aker <brian@tangent.org>
+# Disable LTO to resolve link errors with convenience libraries
+%define _lto_cflags %{nil}
 
 Source: @PACKAGE@-@VERSION@.tar.gz
 Source1: support/gearmand.init
@@ -98,7 +99,6 @@ fi
 %doc AUTHORS COPYING NEWS CONTRIBUTING.md THANKS README.md
 %{_bindir}/gearadmin
 %{_bindir}/gearman
-%{_libdir}/libgearman.la
 %{_libdir}/libgearman.so.8
 %{_libdir}/libgearman.so.8.0.0
 %{_mandir}/man1/gearadmin.1.gz
@@ -316,3 +316,5 @@ fi
 %changelog
 * Wed Jan 7 2009 Brian Aker <brian@tangent.org> - 0.1-1
 - Initial package
+* Mon Apr 13 2026 Edward J. Sabol - 0.2-1
+- Disable LTO and remove libgearman.la from files


### PR DESCRIPTION
This merge request addresses issue #438. The only solution that seemed to work was disabling LTO in the rpmbuild environment.

Successfully tested using the Dockerfile added in the PR.