### PR TITLE
Fix log message truncation in file/stderr write callback

### DIFF
--- a/gearmand/log.hpp
+++ b/gearmand/log.hpp
@@ -130,6 +130,11 @@ struct gearmand_log_info_st
     {
       char buffer[GEARMAN_MAX_ERROR_SIZE * 2 + 16];
       int buffer_length= snprintf(buffer, sizeof(buffer), "%7s %s\n", gearmand_verbose_name(verbose), mesg);
+      if (buffer_length < 0 || buffer_length >= (int)sizeof(buffer))
+      {
+        error::perror("Log buffer truncation detected.");
+        return;
+      }
       if (::write(file(), buffer, buffer_length) == -1)
       {
         error::perror("Could not write to log file.");

--- a/gearmand/log.hpp
+++ b/gearmand/log.hpp
@@ -128,8 +128,8 @@ struct gearmand_log_info_st
   {
     if (opt_file)
     {
-      char buffer[GEARMAN_MAX_ERROR_SIZE];
-      int buffer_length= snprintf(buffer, GEARMAN_MAX_ERROR_SIZE, "%7s %s\n", gearmand_verbose_name(verbose), mesg);
+      char buffer[GEARMAN_MAX_ERROR_SIZE * 2 + 16];
+      int buffer_length= snprintf(buffer, sizeof(buffer), "%7s %s\n", gearmand_verbose_name(verbose), mesg);
       if (::write(file(), buffer, buffer_length) == -1)
       {
         error::perror("Could not write to log file.");


### PR DESCRIPTION
## Summary

- `gearmand_log()` builds its log message into `char log_buffer[GEARMAN_MAX_ERROR_SIZE*2]` (4096 bytes)
- The `write()` method in `gearmand_log_info_st` (`gearmand/log.hpp`) allocated only `char buffer[GEARMAN_MAX_ERROR_SIZE]` (2048 bytes) and passed that same size limit to `snprintf`
- Any log message longer than ~2039 bytes was silently truncated before being written to the log file or stderr
- Fix: increase the write buffer to `GEARMAN_MAX_ERROR_SIZE * 2 + 16` and use `sizeof(buffer)` as the `snprintf` limit

Fixes #67

## Test plan

- [ ] Verify that a log message of length > 2048 bytes is written in full to the log file
- [ ] Confirm no regression in normal (short) log message output
- [ ] Build passes without warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)