### PR TITLE
Log GEARMAN_COMMAND_ERROR text at ERROR level, not WARNING

### DIFF
--- a/libgearman-server/server.cc
+++ b/libgearman-server/server.cc
@@ -78,7 +78,7 @@ static gearmand_error_t _server_error_packet(const char *position_, const char *
   const char* error_code_string= gearman_strerror(client_return_code);
   error_code_string+= 8;
 
-  gearmand_log_warning(position_, func_, "%s:%.*s", gearman_strerror(client_return_code), int(error_string_length), error_string);
+  gearmand_log_error(position_, func_, "%s:%.*s", gearman_strerror(client_return_code), int(error_string_length), error_string);
 
   return gearman_server_io_packet_add(server_con, false, GEARMAN_MAGIC_RESPONSE,
                                       GEARMAN_COMMAND_ERROR, error_code_string,


### PR DESCRIPTION
## Summary

- `_server_error_packet()` was calling `gearmand_log_warning()` to log the error text sent back to clients, but the default verbosity is `GEARMAND_VERBOSE_ERROR` (syslog priority 3)
- `gearmand_log_warning()` only fires when `verbose >= GEARMAND_VERBOSE_WARN` (priority 4), so with default settings `3 >= 4` is false and the log line is silently dropped
- Changed to `gearmand_log_error()` so the error text is visible at the default verbosity level

Fixes #35.

## Test plan

- Start `gearmand` with default verbosity (no `--verbose` flag)
- Trigger a condition that sends a `GEARMAN_COMMAND_ERROR` (e.g. send an unexpected command)
- Confirm the error text now appears in the server log

🤖 Generated with [Claude Code](https://claude.com/claude-code)