### PR TITLE
Set CodeQL build mode to manual

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,6 +46,7 @@ jobs:
       uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
+        build-mode: manual
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.


### PR DESCRIPTION
This PR should silence the following CodeQL workflow warning message:

Initialize CodeQL
Cannot build an overlay database because build-mode is set to "undefined" instead of "none". Falling back to creating a normal full database instead