### PR TITLE
Fix potential double-free of job data on job_queue error path

### DIFF
--- a/libgearman-server/job.cc
+++ b/libgearman-server/job.cc
@@ -274,6 +274,9 @@ gearman_server_job_add_reducer(gearman_server_st *server,
                                  server_job->function->function_name_size);
       }
 
+      /* The caller's packet still has free_data=true and will free data.
+         Null out here to prevent double-free in gearman_server_job_free. */
+      server_job->data= NULL;
       gearman_server_job_free(server_job);
       return NULL;
     }


### PR DESCRIPTION
## Summary

- In `gearman_server_job_add_reducer()`, the error path after `gearman_server_job_queue()` fails did not null out `server_job->data` before calling `gearman_server_job_free()`.
- This is inconsistent with the analogous error path after `gearman_queue_add()` (line 257), which correctly nulls `server_job->data` first.
- When job creation fails, the caller's packet retains `free_data=true`, so `gearmand_packet_free()` will free `packet->data` on the way out. Without the null-out, `gearman_server_job_free()` would also free `server_job->data` (the same pointer) — a double-free.

The code path is currently unreachable because `gearman_server_job_queue()` always returns `GEARMAND_SUCCESS`, but this makes both error paths consistent and removes latent undefined behaviour if that ever changes.

Investigated in the context of #284 (reported memory leak). The investigation found no actual memory leak — freed job data is correctly returned to the allocator, and the apparent Docker memory retention is a glibc malloc / RSS reporting artefact confirmed by `pmap` measurement. This patch fixes the only real code defect found during that investigation.

## Test plan

- [ ] Existing `queue_add` / `queue_worker` tests in `tests/basic.cc` cover the normal background-job path and would catch any regression
- [ ] The fixed error path is unreachable without injecting a `gearman_server_job_queue()` failure, so no new test is practical; correctness is verified by code review and consistency with the existing pattern at line 257

🤖 Generated with [Claude Code](https://claude.com/claude-code)