### PR TITLE
Fix double-free race in multi-threaded connection shutdown (issue #277)

### DIFF
--- a/libgearman-server/connection.cc
+++ b/libgearman-server/connection.cc
@@ -185,10 +185,10 @@ void gearman_server_con_attempt_free(gearman_server_con_st *con)
 
   if (Server->flags.threaded)
   {
+    con->is_dead= true;
     if (!(con->proc_removed) and !(Server->proc_shutdown))
     {
       gearman_server_con_delete_timeout(con);
-      con->is_dead= true;
       con->is_sleeping= false;
       con->is_exceptions= Gearmand()->_exceptions;
       con->is_noop_sent= false;
@@ -197,7 +197,7 @@ void gearman_server_con_attempt_free(gearman_server_con_st *con)
   }
   else
   {
-    gearman_server_con_free(con); 
+    gearman_server_con_free(con);
   }
 }
 
@@ -465,14 +465,15 @@ gearman_server_con_st * gearman_server_con_to_be_freed_next(gearman_server_threa
 
 void gearman_server_con_io_add(gearman_server_con_st *con)
 {
-  if (con->io_list)
-  {
-    return;
-  }
-
   int lock_error;
   if ((lock_error= pthread_mutex_lock(&con->thread->lock)) == 0)
   {
+    if (con->io_list)
+    {
+      pthread_mutex_unlock(&con->thread->lock);
+      return;
+    }
+
     GEARMAND_LIST_ADD(con->thread->io, con, io_);
     con->io_list= true;
 

--- a/libgearman-server/io.cc
+++ b/libgearman-server/io.cc
@@ -896,7 +896,7 @@ gearmand_error_t gearmand_io_set_revents(gearman_server_con_st *con, short reven
 {
   gearmand_io_st *connection= &con->con;
 
-  if (revents != 0)
+  if (revents != 0 && !connection->options.ready)
   {
     connection->options.ready= true;
     GEARMAND_LIST_ADD(connection->universal->ready_con, connection, ready_);


### PR DESCRIPTION
## Summary

Fixes #277 — `t/protocol` intermittently hangs or crashes under `make check`.

Three bugs combined to allow the same `gearmand_con_st` to be freed twice during multi-threaded shutdown, corrupting `free_dcon_list` and crashing the process.

### Bug 1 — `is_dead` not set when `proc_shutdown=true` (`connection.cc`)

`gearman_server_con_attempt_free` only set `con->is_dead = true` when the connection was queued to the proc thread. When `Server->proc_shutdown` was already `true` (second or later worker thread torn down), `is_dead` was never set. A subsequent call to `gearman_server_thread_run` (triggered by a RUN wakeup byte processed in the same `read()` as the SHUTDOWN byte) would then return the already-freed dcon to the caller, causing a second `gearmand_con_free` → second entry in `free_dcon_list` → double-free crash.

**Fix:** Set `con->is_dead = true` unconditionally in threaded mode, before the `proc_shutdown` check.

### Bug 2 — TOCTOU on `io_list` in `gearman_server_con_io_add` (`connection.cc`)

The `con->io_list` guard was read outside the thread mutex. Two threads could both pass the check and both add the same connection to `io_list`.

**Fix:** Move the `io_list` check inside the `pthread_mutex_lock` / `pthread_mutex_unlock` pair.

### Bug 3 — Double-add to `ready_con_list` in `gearmand_io_set_revents` (`io.cc`)

No guard prevented adding the same connection to `ready_con_list` twice when `revents != 0` was delivered more than once.

**Fix:** Skip the list-add if `connection->options.ready` is already set.

## Test plan

- [x] `make check TESTS='t/protocol'` passes
- [x] Ran `t/protocol` 10 consecutive times — all pass (was intermittently failing before)