### PR TITLE
Fix stale job_end pointer when last job is taken from a priority queue

### DIFF
--- a/libgearman-server/gearmand_con.cc
+++ b/libgearman-server/gearmand_con.cc
@@ -422,10 +422,13 @@ gearman_server_job_st *gearman_server_job_take(gearman_server_con_st *server_con
           previous_job->function_next= server_job->function_next;
         }
         
-        // If it's the tail of the list, move the tail back
+        // If it's the tail of the list, move the tail back.
+        // When the list is now empty (single-item case), previous_job still
+        // points at the removed job, so set job_end to NULL instead.
         if (server_job->function->job_end[priority] == server_job)
         {
-          server_job->function->job_end[priority]= previous_job;
+          server_job->function->job_end[priority]=
+            (server_job->function->job_list[priority] == NULL) ? NULL : previous_job;
         }
         server_job->function->job_count--;
 


### PR DESCRIPTION
## Summary

When the only job in a priority queue is taken by `gearman_server_job_take()`, `job_list[priority]` is correctly set to `NULL`, but `job_end[priority]` is set to `previous_job`, which was initialised to the same object that was just removed. This leaves `job_end` pointing at a freed object.

### Root cause (single-item queue)

```
job_list[p] → A ← job_end[p]   (only one job)
```

`previous_job` is initialised to `server_job` (= A). After removal:
- `job_list[p]` = `A->function_next` = `NULL`  ✓
- `job_end[p]`  = `previous_job` = `A`          ✗ (A is freed shortly after)

### Fix

Check whether `job_list[priority]` is `NULL` after removal; if so, set `job_end[priority]` to `NULL` as well:

```c
if (server_job->function->job_end[priority] == server_job)
{
  server_job->function->job_end[priority]=
    (server_job->function->job_list[priority] == NULL) ? NULL : previous_job;
}
```

This is part of the investigation documented in #343 (comment https://github.com/gearman/gearmand/issues/343#issuecomment-4829982675).

## Why no test can demonstrate the bug

`job_end` is read in exactly one place (`job.cc:435`), inside the `else` branch of `gearman_server_job_queue()`:

```c
if (job->function->job_list[job->priority] == NULL)
{
  job->function->job_list[job->priority]= job;        // if-branch: overwrites job_end next
}
else
{
  job->function->job_end[job->priority]->function_next= job;  // else-branch: reads job_end
}
job->function->job_end[job->priority]= job;
```

After the bug condition, `job_list[priority]` is `NULL`. The very next job queued therefore takes the **if-branch**, which overwrites `job_end` with a valid pointer *before* the `else-branch` (the only read site) is ever reachable. The stale pointer is thus never dereferenced — including under AddressSanitizer.

The fix is verified by code inspection: the invariant `job_list[priority] == NULL ↔ job_end[priority] == NULL` is correctly maintained after the change.