### PR TITLE
Fix round-robin worker loop exiting early when an epoch job is not yet runnable

### DIFF
--- a/libgearman-server/gearmand_con.cc
+++ b/libgearman-server/gearmand_con.cc
@@ -366,17 +366,24 @@ gearman_server_job_st *gearman_server_job_take(gearman_server_con_st *server_con
        priority != GEARMAN_JOB_PRIORITY_MAX;
        priority= gearman_job_priority_t(int(priority) +1))
   {
-    for (gearman_server_worker_st *server_worker= server_con->worker_list;
-         server_worker; server_worker= server_worker->con_next)
+    /* Use an explicit while loop so we can save con_next before the
+       round-robin list mutation sets it to NULL on the moved worker. */
+    gearman_server_worker_st *server_worker= server_con->worker_list;
+    while (server_worker)
     {
+      /* Must be read before any list mutation below. */
+      gearman_server_worker_st *next_worker= server_worker->con_next;
+
       if (server_worker->function == NULL || server_worker->function->job_count == 0)
       {
+        server_worker= next_worker;
         continue;
       }
 
       /* Only consider workers that have jobs for this priority. */
       if (server_worker->function->job_list[priority] == NULL)
       {
+        server_worker= next_worker;
         continue;
       }
 
@@ -396,21 +403,23 @@ gearman_server_job_st *gearman_server_job_take(gearman_server_con_st *server_con
         {
           server_con->worker_list= server_worker;
         }
+        /* After the append server_worker->con_next is NULL (it is the new
+           tail). next_worker, saved above, carries the original successor. */
       }
 
       gearman_server_job_st *server_job= server_worker->function->job_list[priority];
       gearman_server_job_st *previous_job= server_job;
-  
+
       int64_t current_time= (int64_t)time(NULL);
-  
+
       while (server_job and server_job->when != 0 and server_job->when > current_time)
       {
         previous_job= server_job;
-        server_job= server_job->function_next;  
+        server_job= server_job->function_next;
       }
-  
+
       if (server_job)
-      { 
+      {
         if (server_job->function->job_list[priority] == server_job)
         {
           // If it's the head of the list, advance it
@@ -421,7 +430,7 @@ gearman_server_job_st *gearman_server_job_take(gearman_server_con_st *server_con
           // Otherwise, just remove the item from the list
           previous_job->function_next= server_job->function_next;
         }
-        
+
         // If it's the tail of the list, move the tail back.
         // When the list is now empty (single-item case), previous_job still
         // points at the removed job, so set job_end to NULL instead.
@@ -441,9 +450,11 @@ gearman_server_job_st *gearman_server_job_take(gearman_server_con_st *server_con
           gearman_server_job_free(server_job);
           return gearman_server_job_take(server_con);
         }
-        
+
         return server_job;
       }
+
+      server_worker= next_worker;
     }
   }
   

--- a/tests/round_robin.cc
+++ b/tests/round_robin.cc
@@ -15,6 +15,7 @@ using namespace libtest;
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <ctime>
 #include <memory>
 #include <unistd.h>
 
@@ -156,7 +157,95 @@ static test_return_t queue_worker(void *object)
   return TEST_SUCCESS;
 }
 
-struct Limit 
+/* ---------------------------------------------------------------------------
+ * round_robin_epoch_does_not_block_regular_TEST
+ *
+ * Regression test for the con_next loop-exit bug in gearman_server_job_take().
+ *
+ * When round-robin is enabled, the inner worker loop moves the chosen worker
+ * to the tail of the list (GEARMAND_LIST_DEL + _server_con_worker_list_append).
+ * After the append, server_worker->con_next is NULL.  If the moved worker's
+ * function has only future-epoch jobs (none runnable right now), the loop
+ * used to advance via the now-NULL con_next and exit early, skipping all
+ * remaining workers -- including any with immediately runnable regular jobs.
+ *
+ * This test registers one worker for two functions (epoch function first),
+ * submits a far-future epoch job to the first function and an immediately
+ * runnable job to the second, then verifies the regular job is dispatched.
+ * On the unfixed code gearman_client_do() would time out; on fixed code it
+ * returns GEARMAN_SUCCESS promptly.
+ * -------------------------------------------------------------------------*/
+
+static gearman_return_t rr_epoch_noop_WORKER(gearman_job_st *job, void *)
+{
+  (void)job;
+  return GEARMAN_SUCCESS;
+}
+
+static gearman_return_t rr_regular_echo_WORKER(gearman_job_st *job, void *)
+{
+  gearman_job_send_data(job,
+                        gearman_job_workload(job),
+                        gearman_job_workload_size(job));
+  return GEARMAN_SUCCESS;
+}
+
+static test_return_t round_robin_epoch_does_not_block_regular_TEST(void *object)
+{
+  Context *context= (Context *)object;
+  ASSERT_TRUE(context);
+
+  /* Submit a far-future epoch job to "rr_epoch_fn" before the worker
+     connects, so the server has a non-runnable job at the head of that
+     function's NORMAL priority queue when the first GRAB_JOB arrives. */
+  libgearman::Client client(context->port());
+  gearman_task_attr_t epoch_attr=
+    gearman_task_attr_init_epoch(time(NULL) + 3600, GEARMAN_JOB_PRIORITY_NORMAL);
+  gearman_argument_t empty= gearman_argument_make(0, 0, NULL, 0);
+  gearman_task_st *epoch_task= gearman_execute(&client,
+                                               test_literal_param("rr_epoch_fn"),
+                                               NULL, 0,
+                                               &epoch_attr, &empty, NULL);
+  ASSERT_TRUE(epoch_task);
+  gearman_task_free(epoch_task);
+
+  /* Start a background worker registered for both functions.  "rr_epoch_fn"
+     is registered first so it appears first in server_con->worker_list,
+     which is the condition that triggers the con_next early-exit bug. */
+  libgearman::Worker w(context->port());
+  gearman_function_t epoch_fn= gearman_function_create(rr_epoch_noop_WORKER);
+  gearman_function_t regular_fn= gearman_function_create(rr_regular_echo_WORKER);
+  ASSERT_EQ(GEARMAN_SUCCESS,
+            gearman_worker_define_function(&w,
+                                           test_literal_param("rr_epoch_fn"),
+                                           epoch_fn, 0, NULL));
+  ASSERT_EQ(GEARMAN_SUCCESS,
+            gearman_worker_define_function(&w,
+                                           test_literal_param("rr_regular_fn"),
+                                           regular_fn, 0, NULL));
+  std::unique_ptr<worker_handle_st> handle(worker_run(w));
+  ASSERT_TRUE(handle.get());
+
+  /* Submit a regular foreground job to "rr_regular_fn" and wait for the
+     result.  With the bug the worker spins (NO_JOB -> PRE_SLEEP -> NOOP ->
+     repeat) and gearman_client_do() times out.  With the fix the worker
+     advances past the epoch function and dispatches the regular job. */
+  gearman_client_set_timeout(&client, 5000);
+  gearman_return_t rc;
+  size_t result_len;
+  void *result= gearman_client_do(&client, "rr_regular_fn", NULL,
+                                  test_literal_param("ping"),
+                                  &result_len, &rc);
+  free(result);
+
+  handle->shutdown();
+
+  ASSERT_EQ(GEARMAN_SUCCESS, rc);
+
+  return TEST_SUCCESS;
+}
+
+struct Limit
 {
   uint32_t _count;
   uint32_t _expected;
@@ -366,6 +455,7 @@ static bool world_destroy(void *object)
 test_st round_robin_TESTS[] ={
   {"add", 0, queue_add },
   {"worker", 0, queue_worker },
+  {"epoch job does not block regular job dispatch", 0, round_robin_epoch_does_not_block_regular_TEST },
   {0, 0, 0}
 };
 


### PR DESCRIPTION
## Summary

`gearman_server_job_take()` iterates the worker list with a `for`-loop that advances via `server_worker->con_next`. When round-robin is enabled, the loop body moves the selected worker to the tail of the list using `GEARMAND_LIST_DEL` + `_server_con_worker_list_append`. After `_server_con_worker_list_append`, `server_worker->con_next` is `NULL` (the worker is now the tail).

If that worker's function has only `SUBMIT_JOB_EPOCH` jobs whose scheduled time has not yet arrived, no job is returned and the loop falls through — but the next iteration reads `server_worker->con_next == NULL` as the successor and exits, **skipping all remaining workers at that priority level**.

Result: a single queued future-epoch job in one function prevents the worker from receiving any regular (immediately runnable) job registered on the same connection, for that priority pass. Because `gearman_server_job_peek()` correctly finds the regular job and sends a NOOP on every PRE_SLEEP, the worker spins in an infinite NOOP→GRAB_JOB→NO_JOB→PRE_SLEEP cycle and the regular job is never dispatched.

**This became unconditional once PR #432 made round-robin the default.**

### Fix

Convert the `for`-loop to a `while`-loop and save `con_next` into `next_worker` at the very top of each iteration, before any list mutation:

```c
gearman_server_worker_st *server_worker = server_con->worker_list;
while (server_worker)
{
  gearman_server_worker_st *next_worker = server_worker->con_next; // save first

  // ... early-exit continues use next_worker ...
  // ... round-robin mutation sets server_worker->con_next = NULL ...
  // ... job search / return ...

  server_worker = next_worker; // safe: mutation did not touch next_worker
}
```

This is part of the investigation documented in #343 (comment https://github.com/gearman/gearmand/issues/343#issuecomment-4829982675).

> **Note for reviewers:** This PR should be merged before or together with #432 — but #432 is already merged, so this fix is now urgent.

## Test plan

An automated regression test is included in `tests/round_robin.cc` (`round_robin_epoch_does_not_block_regular_TEST`):

- Registers one worker for two functions (`rr_epoch_fn` first, `rr_regular_fn` second)
- Submits a far-future epoch job to `rr_epoch_fn`
- Submits a regular foreground job to `rr_regular_fn` and waits for its result via `gearman_client_do()` (5-second timeout)
- Asserts `GEARMAN_SUCCESS` — on the unfixed code, `gearman_client_do()` times out and the assertion fails

The worker runs in a background thread via `worker_run()` because `gearman_server_job_peek()` always finds the regular job and sends an immediate NOOP on every PRE_SLEEP, making any per-IO timeout ineffective.

```
make check TESTS=t/round_robin
```