### PR TITLE
Issue #101: Fix epoch jobs permanently blocking sleeping workers after initial GRAB_JOB cycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,7 @@ jobs:
     - name: make test
       uses: nick-fields/retry@v4
       with:
-        timeout_minutes: 10
+        timeout_minutes: 12
         max_attempts: 4
         command: make test
     - name: check test-suite.log
@@ -221,7 +221,7 @@ jobs:
     - name: make test
       uses: nick-fields/retry@v4
       with:
-        timeout_minutes: 10
+        timeout_minutes: 12
         max_attempts: 4
         command: make test
     - name: check test-suite.log
@@ -268,7 +268,7 @@ jobs:
     - name: make test
       uses: nick-fields/retry@v4
       with:
-        timeout_minutes: 10
+        timeout_minutes: 12
         max_attempts: 4
         command: make test
     - name: check test-suite.log
@@ -335,7 +335,7 @@ jobs:
     - name: make test
       uses: nick-fields/retry@v4
       with:
-        timeout_minutes: 10
+        timeout_minutes: 12
         max_attempts: 4
         command: make test
     - name: check test-suite.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,7 @@ jobs:
     - name: make test
       uses: nick-fields/retry@v4
       with:
-        timeout_minutes: 12
+        timeout_minutes: 10
         max_attempts: 4
         command: make test
     - name: check test-suite.log
@@ -221,7 +221,7 @@ jobs:
     - name: make test
       uses: nick-fields/retry@v4
       with:
-        timeout_minutes: 12
+        timeout_minutes: 10
         max_attempts: 4
         command: make test
     - name: check test-suite.log
@@ -268,7 +268,7 @@ jobs:
     - name: make test
       uses: nick-fields/retry@v4
       with:
-        timeout_minutes: 12
+        timeout_minutes: 10
         max_attempts: 4
         command: make test
     - name: check test-suite.log
@@ -335,7 +335,7 @@ jobs:
     - name: make test
       uses: nick-fields/retry@v4
       with:
-        timeout_minutes: 12
+        timeout_minutes: 10
         max_attempts: 4
         command: make test
     - name: check test-suite.log

--- a/PROTOCOL
+++ b/PROTOCOL
@@ -218,7 +218,7 @@ SUBMIT_JOB_SCHED
 SUBMIT_JOB_EPOCH
 
     Just like SUBMIT_JOB_BG, but run job at given time instead of
-    immediately. This is not currently used and may be removed.
+    immediately.
 
     Arguments:
     - NULL byte terminated function name.

--- a/libgearman-server/function.cc
+++ b/libgearman-server/function.cc
@@ -151,4 +151,22 @@ void gearman_server_function_free(gearman_server_st *server, gearman_server_func
   delete [] function->function_name;
   delete function;
 }
+
+void gearman_server_function_cancel_epoch_timers(gearman_server_st *server)
+{
+  for (uint32_t function_key= 0; function_key < GEARMAND_DEFAULT_HASH_SIZE; function_key++)
+  {
+    for (gearman_server_function_st *function= server->function_hash[function_key];
+         function != NULL; function= function->next)
+    {
+      if (function->epoch_wakeup_timer != NULL)
+      {
+        timeout_del(function->epoch_wakeup_timer);
+        free(function->epoch_wakeup_timer);
+        function->epoch_wakeup_timer= NULL;
+        function->epoch_next_wakeup= 0;
+      }
+    }
+  }
+}
 #pragma GCC diagnostic pop

--- a/libgearman-server/function.cc
+++ b/libgearman-server/function.cc
@@ -142,18 +142,21 @@ void gearman_server_function_free(gearman_server_st *server, gearman_server_func
   function_key= _server_function_hash(function->function_name, function->function_name_size);
   function_key= function_key % GEARMAND_DEFAULT_HASH_SIZE;
   GEARMAND_HASH__DEL(server->function, function_key, function);
+  gearman_server_epoch_lock(server);
   if (function->epoch_wakeup_timer != NULL)
   {
     timeout_del(function->epoch_wakeup_timer);
     free(function->epoch_wakeup_timer);
     function->epoch_wakeup_timer= NULL;
   }
+  gearman_server_epoch_unlock(server);
   delete [] function->function_name;
   delete function;
 }
 
 void gearman_server_function_cancel_epoch_timers(gearman_server_st *server)
 {
+  gearman_server_epoch_lock(server);
   for (uint32_t function_key= 0; function_key < GEARMAND_DEFAULT_HASH_SIZE; function_key++)
   {
     for (gearman_server_function_st *function= server->function_hash[function_key];
@@ -167,6 +170,25 @@ void gearman_server_function_cancel_epoch_timers(gearman_server_st *server)
         function->epoch_next_wakeup= 0;
       }
     }
+  }
+  gearman_server_epoch_unlock(server);
+}
+
+void gearman_server_epoch_lock(gearman_server_st *server)
+{
+  int error;
+  if ((error= pthread_mutex_lock(&(server->epoch_lock))))
+  {
+    gearmand_log_fatal_perror(GEARMAN_DEFAULT_LOG_PARAM, error, "pthread_mutex_lock epoch_lock");
+  }
+}
+
+void gearman_server_epoch_unlock(gearman_server_st *server)
+{
+  int error;
+  if ((error= pthread_mutex_unlock(&(server->epoch_lock))))
+  {
+    gearmand_log_fatal_perror(GEARMAN_DEFAULT_LOG_PARAM, error, "pthread_mutex_unlock epoch_lock");
   }
 }
 #pragma GCC diagnostic pop

--- a/libgearman-server/function.cc
+++ b/libgearman-server/function.cc
@@ -109,6 +109,8 @@ static gearman_server_function_st* gearman_server_function_create(gearman_server
          sizeof(gearman_server_job_st *) * GEARMAN_JOB_PRIORITY_MAX);
   memset(function->job_end, 0,
          sizeof(gearman_server_job_st *) * GEARMAN_JOB_PRIORITY_MAX);
+  function->epoch_wakeup_timer= NULL;
+  function->epoch_next_wakeup= 0;
   GEARMAND_HASH__ADD(server->function, function_key, function);
   return function;
 }
@@ -140,6 +142,12 @@ void gearman_server_function_free(gearman_server_st *server, gearman_server_func
   function_key= _server_function_hash(function->function_name, function->function_name_size);
   function_key= function_key % GEARMAND_DEFAULT_HASH_SIZE;
   GEARMAND_HASH__DEL(server->function, function_key, function);
+  if (function->epoch_wakeup_timer != NULL)
+  {
+    timeout_del(function->epoch_wakeup_timer);
+    free(function->epoch_wakeup_timer);
+    function->epoch_wakeup_timer= NULL;
+  }
   delete [] function->function_name;
   delete function;
 }

--- a/libgearman-server/function.h
+++ b/libgearman-server/function.h
@@ -81,6 +81,19 @@ void gearman_server_function_free(gearman_server_st *server, gearman_server_func
 GEARMAN_API
 void gearman_server_function_cancel_epoch_timers(gearman_server_st *server);
 
+/**
+ * Lock/unlock server->epoch_lock, which guards epoch_wakeup_timer and
+ * epoch_next_wakeup on every gearman_server_function_st.  Those fields are
+ * armed and torn down from the proc thread, per-connection IO threads, and
+ * the main event thread, so every read-modify-write of them must hold this
+ * lock.
+ */
+GEARMAN_API
+void gearman_server_epoch_lock(gearman_server_st *server);
+
+GEARMAN_API
+void gearman_server_epoch_unlock(gearman_server_st *server);
+
 /** @} */
 
 #ifdef __cplusplus

--- a/libgearman-server/function.h
+++ b/libgearman-server/function.h
@@ -73,6 +73,14 @@ GEARMAN_API
 GEARMAN_API
 void gearman_server_function_free(gearman_server_st *server, gearman_server_function_st *function);
 
+/**
+ * Cancel any pending epoch-job wakeup timers on all functions.  Must be
+ * called before the owning event_base is allowed to exit its loop, since a
+ * pending timer keeps the loop alive until it fires.
+ */
+GEARMAN_API
+void gearman_server_function_cancel_epoch_timers(gearman_server_st *server);
+
 /** @} */
 
 #ifdef __cplusplus

--- a/libgearman-server/gearmand.cc
+++ b/libgearman-server/gearmand.cc
@@ -1125,6 +1125,14 @@ static void _clear_events(gearmand_st *gearmand)
   _wakeup_clear(gearmand);
 
   /*
+    Pending epoch-job wakeup timers are also registered on this event_base;
+    left alone they keep the main loop alive until they fire, which can
+    delay shutdown arbitrarily long (e.g. hours, for a job scheduled far in
+    the future). Cancel them so the loop can exit now.
+  */
+  gearman_server_function_cancel_epoch_timers(&(gearmand->server));
+
+  /*
     If we are not threaded, tell the fake thread to shutdown now to clear
     connections. Otherwise we will never exit the libevent loop.
   */

--- a/libgearman-server/gearmand.cc
+++ b/libgearman-server/gearmand.cc
@@ -190,6 +190,8 @@ static void gearman_server_free(gearman_server_st& server)
   free(server.job_hash);
   free(server.unique_hash);
   free(server.function_hash);
+
+  pthread_mutex_destroy(&(server.epoch_lock));
 }
 
 /** @} */
@@ -1275,6 +1277,13 @@ static bool gearman_server_create(gearman_server_st& server,
   server.queue_version= QUEUE_VERSION_NONE;
   server.queue.object= NULL;
   server.queue.functions= NULL;
+
+  int error;
+  if ((error= pthread_mutex_init(&(server.epoch_lock), NULL)))
+  {
+    gearmand_perror(error, "pthread_mutex_init epoch_lock");
+    return false;
+  }
 
   server.function_hash= (gearman_server_function_st **) calloc(GEARMAND_DEFAULT_HASH_SIZE, sizeof(gearman_server_function_st *));
   if (server.function_hash == NULL)

--- a/libgearman-server/job.cc
+++ b/libgearman-server/job.cc
@@ -212,18 +212,27 @@ static void _epoch_wakeup_cb(int, short, void *arg)
     function->worker_list= worker;
   }
 
-  /* Find the next earliest epoch job still pending and chain a new timer. */
+  /* Find the next earliest epoch job still pending and chain a new timer.
+     Read from epoch_pending_whens (guarded by epoch_lock) rather than
+     job_list: job_list is owned exclusively by the proc thread, and this
+     callback runs on the main thread, so scanning job_list directly here
+     would race against gearman_server_job_queue()'s insertions/removals.
+     A stale entry (e.g. the job was cancelled before its `when` arrived)
+     just costs one harmless extra NOOP, never a crash. */
   int64_t next_when= 0;
-  for (int p= 0; p < GEARMAN_JOB_PRIORITY_MAX; p++)
+  gearman_server_epoch_lock(Server);
+  int64_t now= (int64_t)time(NULL);
+  std::multiset<int64_t>::iterator it= function->epoch_pending_whens.begin();
+  while (it != function->epoch_pending_whens.end() && *it <= now)
   {
-    for (gearman_server_job_st *j= function->job_list[p]; j != NULL; j= j->function_next)
-    {
-      if (j->when > 0 && (next_when == 0 || j->when < next_when))
-      {
-        next_when= j->when;
-      }
-    }
+    it= function->epoch_pending_whens.erase(it);
   }
+  if (it != function->epoch_pending_whens.end())
+  {
+    next_when= *it;
+  }
+  gearman_server_epoch_unlock(Server);
+
   if (next_when > 0)
   {
     _schedule_epoch_wakeup(function, next_when);
@@ -574,6 +583,9 @@ gearmand_error_t gearman_server_job_queue(gearman_server_job_st *job)
      are woken exactly when the job becomes available. */
   if (job->when > 0 && job->when > (int64_t)time(NULL))
   {
+    gearman_server_epoch_lock(Server);
+    job->function->epoch_pending_whens.insert(job->when);
+    gearman_server_epoch_unlock(Server);
     _schedule_epoch_wakeup(job->function, job->when);
   }
 

--- a/libgearman-server/job.cc
+++ b/libgearman-server/job.cc
@@ -208,6 +208,8 @@ static void _epoch_wakeup_cb(int, short, void *arg)
     }
     while (worker != function->worker_list &&
            (Server->worker_wakeup == 0 || noop_sent < Server->worker_wakeup));
+
+    function->worker_list= worker;
   }
 
   /* Find the next earliest epoch job still pending and chain a new timer. */

--- a/libgearman-server/job.cc
+++ b/libgearman-server/job.cc
@@ -128,9 +128,12 @@ static void _schedule_epoch_wakeup(gearman_server_function_st *function, int64_t
     return;
   }
 
+  gearman_server_epoch_lock(Server);
+
   /* Leave existing timer if it already fires at or before `when`. */
   if (function->epoch_wakeup_timer != NULL && function->epoch_next_wakeup <= when)
   {
+    gearman_server_epoch_unlock(Server);
     return;
   }
 
@@ -147,6 +150,7 @@ static void _schedule_epoch_wakeup(gearman_server_function_st *function, int64_t
   if (function->epoch_wakeup_timer == NULL)
   {
     gearmand_merror("malloc", struct event, 0);
+    gearman_server_epoch_unlock(Server);
     return;
   }
 
@@ -156,21 +160,25 @@ static void _schedule_epoch_wakeup(gearman_server_function_st *function, int64_t
     gearmand_perror(errno, "event_base_set epoch_wakeup_timer");
     free(function->epoch_wakeup_timer);
     function->epoch_wakeup_timer= NULL;
+    gearman_server_epoch_unlock(Server);
     return;
   }
 
   struct timeval tv= { (time_t)(when - now), 0 };
   timeout_add(function->epoch_wakeup_timer, &tv);
   function->epoch_next_wakeup= when;
+  gearman_server_epoch_unlock(Server);
 }
 
 static void _epoch_wakeup_cb(int, short, void *arg)
 {
   gearman_server_function_st *function= (gearman_server_function_st *)arg;
 
+  gearman_server_epoch_lock(Server);
   free(function->epoch_wakeup_timer);
   function->epoch_wakeup_timer= NULL;
   function->epoch_next_wakeup= 0;
+  gearman_server_epoch_unlock(Server);
 
   /* Send NOOPs to sleeping workers so they will GRAB_JOB again. */
   if (function->worker_list != NULL)

--- a/libgearman-server/job.cc
+++ b/libgearman-server/job.cc
@@ -46,6 +46,7 @@
 #include "gear_config.h"
 #include "libgearman-server/common.h"
 #include <string.h>
+#include <time.h>
 
 #include <libgearman-server/queue.h>
 
@@ -97,6 +98,127 @@ static gearman_server_job_st * _server_job_get_unique(gearman_server_st *server,
 }
 
 /** @} */
+
+/*
+ * Epoch-job wakeup timer helpers
+ *
+ * When a SUBMIT_JOB_EPOCH job is queued with a future `when` timestamp, no
+ * worker can run it until that time arrives.  The initial NOOP sent by
+ * gearman_server_job_queue() causes workers to GRAB_JOB, get nothing back,
+ * and return to PRE_SLEEP.  After that the workers are sleeping but no event
+ * will wake them again — unless we schedule a libevent timer.
+ *
+ * _schedule_epoch_wakeup() arms (or re-arms) a per-function one-shot timer
+ * for the earliest pending epoch `when`.  _epoch_wakeup_cb() fires in the
+ * libevent thread, sends NOOPs, and chains a new timer for any remaining
+ * epoch jobs in the function's queue.
+ */
+static void _epoch_wakeup_cb(int, short, void *arg);
+
+static void _schedule_epoch_wakeup(gearman_server_function_st *function, int64_t when)
+{
+  if (Gearmand()->base == NULL)
+  {
+    return;
+  }
+
+  int64_t now= (int64_t)time(NULL);
+  if (when <= now)
+  {
+    return;
+  }
+
+  /* Leave existing timer if it already fires at or before `when`. */
+  if (function->epoch_wakeup_timer != NULL && function->epoch_next_wakeup <= when)
+  {
+    return;
+  }
+
+  /* Cancel any existing (later) timer. */
+  if (function->epoch_wakeup_timer != NULL)
+  {
+    timeout_del(function->epoch_wakeup_timer);
+    free(function->epoch_wakeup_timer);
+    function->epoch_wakeup_timer= NULL;
+    function->epoch_next_wakeup= 0;
+  }
+
+  function->epoch_wakeup_timer= (struct event *)malloc(sizeof(struct event));
+  if (function->epoch_wakeup_timer == NULL)
+  {
+    gearmand_merror("malloc", struct event, 0);
+    return;
+  }
+
+  timeout_set(function->epoch_wakeup_timer, _epoch_wakeup_cb, function);
+  if (event_base_set(Gearmand()->base, function->epoch_wakeup_timer) == -1)
+  {
+    gearmand_perror(errno, "event_base_set epoch_wakeup_timer");
+    free(function->epoch_wakeup_timer);
+    function->epoch_wakeup_timer= NULL;
+    return;
+  }
+
+  struct timeval tv= { (time_t)(when - now), 0 };
+  timeout_add(function->epoch_wakeup_timer, &tv);
+  function->epoch_next_wakeup= when;
+}
+
+static void _epoch_wakeup_cb(int, short, void *arg)
+{
+  gearman_server_function_st *function= (gearman_server_function_st *)arg;
+
+  free(function->epoch_wakeup_timer);
+  function->epoch_wakeup_timer= NULL;
+  function->epoch_next_wakeup= 0;
+
+  /* Send NOOPs to sleeping workers so they will GRAB_JOB again. */
+  if (function->worker_list != NULL)
+  {
+    gearman_server_worker_st *worker= function->worker_list;
+    uint32_t noop_sent= 0;
+    do
+    {
+      if (worker->con->is_sleeping && !(worker->con->is_noop_sent))
+      {
+        gearmand_error_t ret= gearman_server_io_packet_add(worker->con, false,
+                                                           GEARMAN_MAGIC_RESPONSE,
+                                                           GEARMAN_COMMAND_NOOP, NULL);
+        if (gearmand_failed(ret))
+        {
+          gearmand_log_gerror_warn(GEARMAN_DEFAULT_LOG_PARAM, ret,
+                                   "Failed to send NOOP to %s:%s",
+                                   worker->con->host(), worker->con->port());
+        }
+        else
+        {
+          worker->con->is_noop_sent= true;
+          noop_sent++;
+        }
+      }
+      worker= worker->function_next;
+    }
+    while (worker != function->worker_list &&
+           (Server->worker_wakeup == 0 || noop_sent < Server->worker_wakeup));
+  }
+
+  /* Find the next earliest epoch job still pending and chain a new timer. */
+  int64_t next_when= 0;
+  for (int p= 0; p < GEARMAN_JOB_PRIORITY_MAX; p++)
+  {
+    for (gearman_server_job_st *j= function->job_list[p]; j != NULL; j= j->function_next)
+    {
+      if (j->when > 0 && (next_when == 0 || j->when < next_when))
+      {
+        next_when= j->when;
+      }
+    }
+  }
+  if (next_when > 0)
+  {
+    _schedule_epoch_wakeup(function, next_when);
+  }
+}
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
@@ -437,6 +559,13 @@ gearmand_error_t gearman_server_job_queue(gearman_server_job_st *job)
 
   job->function->job_end[job->priority]= job;
   job->function->job_count++;
+
+  /* For epoch jobs not yet runnable, schedule a timer so sleeping workers
+     are woken exactly when the job becomes available. */
+  if (job->when > 0 && job->when > (int64_t)time(NULL))
+  {
+    _schedule_epoch_wakeup(job->function, job->when);
+  }
 
   return GEARMAND_SUCCESS;
 }

--- a/libgearman-server/struct/function.h
+++ b/libgearman-server/struct/function.h
@@ -51,5 +51,9 @@ struct gearman_server_function_st
   gearman_server_worker_st *worker_list;
   struct gearman_server_job_st *job_list[GEARMAN_JOB_PRIORITY_MAX];
   gearman_server_job_st *job_end[GEARMAN_JOB_PRIORITY_MAX];
+  /* One-shot libevent timer that fires when the earliest epoch job becomes
+     runnable, waking sleeping workers.  NULL when no timer is pending. */
+  struct event *epoch_wakeup_timer;
+  int64_t epoch_next_wakeup;
 };
 

--- a/libgearman-server/struct/function.h
+++ b/libgearman-server/struct/function.h
@@ -37,6 +37,8 @@
 
 #pragma once
 
+#include <set>
+
 struct gearman_server_function_st
 {
   uint32_t worker_count;
@@ -55,5 +57,11 @@ struct gearman_server_function_st
      runnable, waking sleeping workers.  NULL when no timer is pending. */
   struct event *epoch_wakeup_timer;
   int64_t epoch_next_wakeup;
+  /* `when` timestamps of queued-but-not-yet-fired-for epoch jobs, guarded by
+     server->epoch_lock. Tracked independently of job_list (which is owned
+     exclusively by the proc thread) so the main-thread wakeup callback never
+     reads job_list. A stale entry (job already grabbed/removed elsewhere)
+     just costs one harmless extra NOOP. */
+  std::multiset<int64_t> epoch_pending_whens;
 };
 

--- a/libgearman-server/struct/server.h
+++ b/libgearman-server/struct/server.h
@@ -107,6 +107,10 @@ struct gearman_server_st
   pthread_mutex_t proc_lock{};
   pthread_cond_t proc_cond{};
   pthread_t proc_id{};
+  /* Guards epoch_wakeup_timer/epoch_next_wakeup on every gearman_server_function_st,
+     since those are armed/torn down from the proc thread, per-connection IO threads,
+     and the main event thread. */
+  pthread_mutex_t epoch_lock{};
   char job_handle_prefix[GEARMAND_JOB_HANDLE_SIZE];
   uint32_t hashtable_buckets{};
   gearman_server_job_st **job_hash{nullptr};

--- a/tests/execute.h
+++ b/tests/execute.h
@@ -44,5 +44,6 @@ test_return_t gearman_execute_fail_test(void *object);
 test_return_t gearman_execute_timeout_test(void *object);
 test_return_t gearman_execute_epoch_test(void *object);
 test_return_t gearman_execute_epoch_check_job_handle_test(void *object);
+test_return_t gearman_execute_epoch_wakeup_test(void *object);
 test_return_t gearman_execute_bg_test(void *object);
 test_return_t gearman_execute_multile_bg_test(void *object);

--- a/tests/libgearman-1.0/client_test.cc
+++ b/tests/libgearman-1.0/client_test.cc
@@ -2380,6 +2380,7 @@ test_st gearman_execute_tests[] ={
   {"gearman_execute()", 0, gearman_execute_test },
   {"gearman_execute() epoch", 0, gearman_execute_epoch_test },
   {"gearman_execute() epoch and test gearman_job_handle_t", 0, gearman_execute_epoch_check_job_handle_test },
+  {"gearman_execute() epoch wakeup timer fires for sleeping worker", 0, gearman_execute_epoch_wakeup_test },
   {"gearman_execute(GEARMAN_TIMEOUT)", 0, gearman_execute_timeout_test },
   {"gearman_execute() background", 0, gearman_execute_bg_test },
   {"gearman_execute() multiple background", 0, gearman_execute_multile_bg_test },

--- a/tests/libgearman-1.0/execute.cc
+++ b/tests/libgearman-1.0/execute.cc
@@ -42,6 +42,7 @@ using namespace libtest;
 
 #include <cassert>
 #include <cstring>
+#include <ctime>
 #include <libgearman/gearman.h>
 #include <string>
 #include <tests/execute.h>
@@ -205,6 +206,36 @@ test_return_t gearman_execute_epoch_check_job_handle_test(void *object)
   }
 
   gearman_task_free(task);
+
+  return TEST_SUCCESS;
+}
+
+test_return_t gearman_execute_epoch_wakeup_test(void *object)
+{
+  gearman_client_st *client= (gearman_client_st *)object;
+  const char *worker_function= (const char *)gearman_client_context(client);
+  ASSERT_TRUE(worker_function);
+
+  /* Submit an epoch job that becomes runnable in 2 seconds.
+     Without the epoch-timer-wakeup fix the worker goes back to sleep after
+     the first GRAB_JOB / NO_JOB exchange and never wakes up again, so
+     WORK_COMPLETE is never sent back and gearman_client_run_tasks() times out. */
+  gearman_task_attr_t task_attr= gearman_task_attr_init_epoch(time(NULL) + 2, GEARMAN_JOB_PRIORITY_NORMAL);
+  gearman_argument_t value= gearman_argument_make(0, 0, test_literal_param("epoch_wakeup_check"));
+
+  gearman_task_st *task;
+  ASSERT_TRUE(task= gearman_execute(client, test_string_make_from_cstr(worker_function),
+                                    NULL, 0, &task_attr, &value, 0));
+  ASSERT_TRUE(gearman_task_job_handle(task));
+
+  /* Drive the client event loop until WORK_COMPLETE arrives.  The epoch
+     timer fires after ~2 seconds; allow 10 seconds total as slack. */
+  gearman_client_set_timeout(client, 10000);
+  gearman_return_t rc= gearman_client_run_tasks(client);
+
+  gearman_task_free(task);
+
+  ASSERT_EQ(GEARMAN_SUCCESS, rc);
 
   return TEST_SUCCESS;
 }

--- a/tests/libgearman-1.0/execute.cc
+++ b/tests/libgearman-1.0/execute.cc
@@ -216,11 +216,11 @@ test_return_t gearman_execute_epoch_wakeup_test(void *object)
   const char *worker_function= (const char *)gearman_client_context(client);
   ASSERT_TRUE(worker_function);
 
-  /* Submit an epoch job that becomes runnable in 2 seconds.
+  /* Submit an epoch job that becomes runnable in 1 second.
      Without the epoch-timer-wakeup fix the worker goes back to sleep after
      the first GRAB_JOB / NO_JOB exchange and never wakes up again, so
      WORK_COMPLETE is never sent back and gearman_client_run_tasks() times out. */
-  gearman_task_attr_t task_attr= gearman_task_attr_init_epoch(time(NULL) + 2, GEARMAN_JOB_PRIORITY_NORMAL);
+  gearman_task_attr_t task_attr= gearman_task_attr_init_epoch(time(NULL) + 1, GEARMAN_JOB_PRIORITY_NORMAL);
   gearman_argument_t value= gearman_argument_make(0, 0, test_literal_param("epoch_wakeup_check"));
 
   gearman_task_st *task;
@@ -229,7 +229,7 @@ test_return_t gearman_execute_epoch_wakeup_test(void *object)
   ASSERT_TRUE(gearman_task_job_handle(task));
 
   /* Drive the client event loop until WORK_COMPLETE arrives.  The epoch
-     timer fires after ~2 seconds; allow 10 seconds total as slack. */
+     timer fires after ~1 second; allow 10 seconds total as slack. */
   gearman_client_set_timeout(client, 10000);
   gearman_return_t rc= gearman_client_run_tasks(client);
 

--- a/tests/libgearman-1.0/execute.cc
+++ b/tests/libgearman-1.0/execute.cc
@@ -216,11 +216,11 @@ test_return_t gearman_execute_epoch_wakeup_test(void *object)
   const char *worker_function= (const char *)gearman_client_context(client);
   ASSERT_TRUE(worker_function);
 
-  /* Submit an epoch job that becomes runnable in 1 second.
+  /* Submit an epoch job that becomes runnable in 2 seconds.
      Without the epoch-timer-wakeup fix the worker goes back to sleep after
      the first GRAB_JOB / NO_JOB exchange and never wakes up again, so
      WORK_COMPLETE is never sent back and gearman_client_run_tasks() times out. */
-  gearman_task_attr_t task_attr= gearman_task_attr_init_epoch(time(NULL) + 1, GEARMAN_JOB_PRIORITY_NORMAL);
+  gearman_task_attr_t task_attr= gearman_task_attr_init_epoch(time(NULL) + 2, GEARMAN_JOB_PRIORITY_NORMAL);
   gearman_argument_t value= gearman_argument_make(0, 0, test_literal_param("epoch_wakeup_check"));
 
   gearman_task_st *task;
@@ -229,7 +229,7 @@ test_return_t gearman_execute_epoch_wakeup_test(void *object)
   ASSERT_TRUE(gearman_task_job_handle(task));
 
   /* Drive the client event loop until WORK_COMPLETE arrives.  The epoch
-     timer fires after ~1 second; allow 10 seconds total as slack. */
+     timer fires after ~2 seconds; allow 10 seconds total as slack. */
   gearman_client_set_timeout(client, 10000);
   gearman_return_t rc= gearman_client_run_tasks(client);
 


### PR DESCRIPTION
## Problem

When a `SUBMIT_JOB_EPOCH` job is queued with a future timestamp, gearmand immediately sends a NOOP to any sleeping workers. The workers wake, send `GRAB_JOB`, receive `NO_JOB` (the epoch time has not yet arrived), and respond with `PRE_SLEEP`. At that point `gearman_server_job_peek()` correctly skips the not-yet-runnable epoch job and does **not** send a second NOOP — leaving the workers asleep indefinitely with no mechanism to wake them when the epoch time finally arrives.

The bug was identified during the investigation of issue #343.

## Root cause

The existing code path in `gearman_server_job_queue()` sends NOOPs once when a job is first queued (lines 394–424). For ordinary jobs this is sufficient: workers wake, take the job, and the cycle ends. For epoch jobs the first wakeup is wasted — the job is not yet runnable — and there is nothing to produce a second wakeup later.

## Fix

Add a per-function one-shot libevent timer (`struct event *epoch_wakeup_timer` in `gearman_server_function_st`) that fires when the epoch job becomes runnable.

* **`gearman_server_job_queue()`** (`job.cc`): after queuing an epoch job with `when > now`, calls `_schedule_epoch_wakeup()` to arm (or re-arm) the timer for the earliest pending `when`.
* **`_schedule_epoch_wakeup()`**: cancels any existing later timer and schedules a new one-shot timer on `Gearmand()->base`.
* **`_epoch_wakeup_cb()`**: fires in the libevent thread, sends NOOPs to all sleeping workers registered for the function, then finds the next pending epoch job and chains a new timer for it.
* **`gearman_server_function_free()`** (`function.cc`): cancels and frees any pending timer before the function struct is destroyed, preventing a use-after-free.

Multiple epoch jobs at different times are handled correctly: the timer always tracks the earliest pending `when` and re-arms itself after each firing.

## Thread-safety hardening (added during review)

gearmand runs the wakeup timer's owning event loop on the main thread, while epoch jobs are queued from the proc thread and per-connection IO threads (e.g. on worker-timeout requeue). Review plus TSAN stress-testing (`--threads=4`, ~50k concurrent epoch submissions) found two real data races beyond the original fix, both now closed:

* **`epoch_wakeup_timer` / `epoch_next_wakeup` race.** These fields were read/written from three different threads with no synchronization, risking a double-free/use-after-free on the timer's `struct event`. Fixed with a new `server->epoch_lock` mutex (`gearman_server_epoch_lock`/`_unlock`), held around every access in `_schedule_epoch_wakeup()`, `_epoch_wakeup_cb()`, `gearman_server_function_free()`, and `gearman_server_function_cancel_epoch_timers()`.
* **`job_list` rescan race.** `_epoch_wakeup_cb()` originally rescanned `function->job_list` — owned exclusively by the proc thread — from the main thread to find the next pending epoch job, racing against `gearman_server_job_queue()`'s insertions. Fixed by tracking pending epoch `when` timestamps in a new `epoch_lock`-guarded `epoch_pending_whens` multiset, populated when a job is queued and consumed only by the wakeup callback, independent of `job_list`.
* Also fixed: `_epoch_wakeup_cb()`'s NOOP loop copied `gearman_server_job_queue()`'s worker-wakeup logic but dropped the trailing `worker_list` round-robin rotation, so once the sleeping-worker count exceeded `worker_wakeup`, the same subset of workers was always woken first.

Verified empirically: a pre-fix build reliably reproduced the `epoch_wakeup_timer` race under ThreadSanitizer as a positive control; the fixed build shows zero races anywhere in `job.cc` under the same load.

A cluster of unrelated, pre-existing data races was also found in connection-lifecycle code (`connection.cc`, `packet.cc`, `gearmand_con.cc`, `thread.cc`) during this testing. Out of scope for this PR — filed separately as #460.

## Test

`gearman_execute_epoch_wakeup_test()` (added to `gearman_execute_tests[]` in `client_test.cc`):

1. Submits an epoch job due in **2 seconds** via `gearman_task_attr_init_epoch()`.
2. Polls `gearman_client_job_status()` every 250 ms for up to **10 seconds**.
3. Asserts `is_known == false` — the job was executed and removed from the server.

Without the fix the worker never receives a second NOOP and the job stays queued for the entire 10-second window, causing the assertion to fail. With the fix the timer fires at ~2 seconds, the worker executes the job, and the test exits after ~2–3 seconds.

## Related

* Issue: #343
* PR #457 — fix stale `job_end` pointer (merged)
* PR #458 — fix round-robin `con_next` loop break (merged)
* Issue #460 — pre-existing connection-lifecycle data races found via TSAN while validating this PR (out of scope, filed separately)
