### PR TITLE
Issue #58: Fix pthread_timedjoin_np detection on FreeBSD, make macro self-contained

### DIFF
--- a/libgearman-server/gearmand_thread.cc
+++ b/libgearman-server/gearmand_thread.cc
@@ -50,6 +50,10 @@
 #include <memory>
 #include <csignal>
 
+#ifdef HAVE_PTHREAD_NP_H
+# include <pthread_np.h>
+#endif
+
 /*
  * Private declarations
  */

--- a/m4/ax_pthread_timedjoin_np.m4
+++ b/m4/ax_pthread_timedjoin_np.m4
@@ -19,11 +19,16 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 6
+#serial 7
 
 AC_DEFUN([AX_PTHREAD_TIMEDJOIN_NP],
     [AC_PREREQ([2.63])dnl
     AC_REQUIRE([AX_PTHREAD])
+
+    dnl FreeBSD keeps pthread_timedjoin_np's prototype in pthread_np.h,
+    dnl separate from pthread.h.
+    AC_CHECK_HEADERS([pthread_np.h])
+
     AC_CACHE_CHECK([check for pthread_timedjoin_np], [ax_cv_pthread_timedjoin_np],
       [AX_SAVE_FLAGS
       CFLAGS="$PTHREAD_CFLAGS"
@@ -32,13 +37,19 @@ AC_DEFUN([AX_PTHREAD_TIMEDJOIN_NP],
       AC_LINK_IFELSE(
         [AC_LANG_PROGRAM(
           [
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE
+#endif
 #include <pthread.h>
 #include <stdlib.h>
+#ifdef HAVE_PTHREAD_NP_H
+# include <pthread_np.h>
+#endif
           ],[
           pthread_t thread;
           pthread_timedjoin_np(thread, NULL, NULL);
           ])],
-        [ax_cv_pthread_timedjoin_np=yes],[])
+        [ax_cv_pthread_timedjoin_np=yes],[ax_cv_pthread_timedjoin_np=no])
 
       AC_LANG_POP
       AX_RESTORE_FLAGS

--- a/tests/hostile.cc
+++ b/tests/hostile.cc
@@ -60,6 +60,10 @@ using namespace org::gearmand;
 #include <unistd.h>
 #include <sys/time.h>
 
+#ifdef HAVE_PTHREAD_NP_H
+# include <pthread_np.h>
+#endif
+
 #define WORKER_FUNCTION_NAME "foo"
 
 #ifndef SERVER_TARGET


### PR DESCRIPTION
## Summary

Fixes the FreeBSD build failure reported in #58: `pthread_timedjoin_np` was not declared in this scope in `libgearman-server/gearmand_thread.cc`.

Root cause: on FreeBSD, `pthread_timedjoin_np`'s prototype lives in `<pthread_np.h>`, not `<pthread.h>`. The symbol itself exists in `libthr` (`pthread_timedjoin_np@@FBSD_1.0`), so `m4/ax_pthread_timedjoin_np.m4`'s `AC_LINK_IFELSE` check silently succeeded on FreeBSD and set `HAVE_PTHREAD_TIMEDJOIN_NP=1`, even though the real call sites never included the header needed to see the declaration — breaking the C++ build.

- `m4/ax_pthread_timedjoin_np.m4`: adds `AC_CHECK_HEADERS([pthread_np.h])` and includes it conditionally in the detection test; also adds a guarded `_GNU_SOURCE` define so the macro detects correctly standalone, without depending on the including project calling `AC_USE_SYSTEM_EXTENSIONS` first (this was also independently flagged in the issue thread); initializes the cache var to `no` on failure.
- `libgearman-server/gearmand_thread.cc` / `tests/hostile.cc`: conditionally include `<pthread_np.h>` when present, matching what the macro now detects.

`libmemcached` carries an identical, unfixed copy of this same macro (unchanged since 2012) — no upstream fix was available to pull in.

## Test plan

- [x] Verified via an isolated macro repro (matching `configure.ac`'s exact `AC_USE_SYSTEM_EXTENSIONS` → `AX_PTHREAD` → `AX_PTHREAD_TIMEDJOIN_NP` ordering) on Linux (GCC 15.2.0 / glibc 2.42): `HAVE_PTHREAD_TIMEDJOIN_NP` still correctly resolves to `1`, `HAVE_PTHREAD_NP_H` correctly absent — no regression.
- [x] Verified the macro is now self-contained: detects correctly even without `AC_USE_SYSTEM_EXTENSIONS` in the including project.
- [x] Built and tested on a real FreeBSD 15.0-RELEASE VM (QEMU): confirmed `pthread_timedjoin_np` is declared only in `pthread_np.h`; ran `autoreconf` + `./configure` and confirmed `HAVE_PTHREAD_NP_H=1` / `HAVE_PTHREAD_TIMEDJOIN_NP=1`; compiled `gearmand_thread.cc` and `hostile.cc` cleanly; built and linked the full `gearmand` daemon binary and ran `gearmand --version` successfully.

Closes #58