### PR TITLE
Update docs/manpage to document that --round-robin is the new default

### DIFF
--- a/docs/source/gearmand.rst
+++ b/docs/source/gearmand.rst
@@ -57,7 +57,7 @@ SYNOPSIS
 
 .. option:: -R [ --round-robin ]
 
-   Assign work in round-robin order per worker connection. The default is to assign work in the order of functions added by the worker.
+   Assign work in round-robin order per worker connection. As of version 2.0.0, this is the default behavior, and it cannot be deactivated. This command line option does nothing, and its continued existence is only supported for backwards compatibility.
 
 .. option:: -q [ --queue-type ] arg
 

--- a/gearmand/gearmand.cc
+++ b/gearmand/gearmand.cc
@@ -179,7 +179,7 @@ int main(int argc, char *argv[])
    "Load protocol module.")
 
   ("round-robin,R", boost::program_options::bool_switch(&opt_round_robin)->default_value(true),
-   "Assign work in round-robin order per worker connection. This is the default behavior, and it cannot be deactivated. This option is only provided for backwards compatibility.")
+   "Assign work in round-robin order per worker connection. This is the default behavior, and it cannot be deactivated. This command line option does nothing and is only supported for backwards compatibility.")
 
   ("queue-type,q", boost::program_options::value(&queue_type)->default_value("builtin"),
    "Persistent queue type to use.")


### PR DESCRIPTION
This PR updates the `gearmand.rst` file used to generate the HTML web pages and gearmand man page to document the change merged in PR #432.

It also makes some minor improvements (for clarity) to the already updated `boost::program_options` help text that is displayed when the user invokes `--help` on the command line.