### PR TITLE
Assert aggregated content in gearman_execute_partition_basic

### DIFF
--- a/tests/libgearman-1.0/gearman_execute_partition.cc
+++ b/tests/libgearman-1.0/gearman_execute_partition.cc
@@ -154,6 +154,13 @@ test_return_t gearman_execute_partition_basic(void *object)
   ASSERT_TRUE(value);
   ASSERT_EQ(18UL, gearman_result_size(result));
 
+  // cat_aggregator_fn() concatenates the sub-task results in task-list
+  // order, which is submission order (FIFO, since PR #435). split_worker()
+  // splits "this dog does not hunt" on spaces in left-to-right order, so
+  // the aggregated result is expected to be the words back-to-back in
+  // their original order.
+  test_memcmp("thisdogdoesnothunt", value, 18);
+
   gearman_task_free(task);
   gearman_client_task_free_all(client);
 


### PR DESCRIPTION
## Summary

- `gearman_execute_partition_basic` only asserted the aggregated result *size* (18 bytes), never its content, so PR #435's ordering change (client task queue LIFO → FIFO) could silently flip the order `cat_aggregator_fn` concatenates sub-task results in — reverse-word-order to forward-word-order — without any test catching it.
- Adds a `test_memcmp` assertion pinning the aggregated result to `"thisdogdoesnothunt"`, the expected FIFO/submission order.

As discussed on #464: this specifically covers the aggregator's reduce-order dependency (`cat_aggregator_fn` walking `task_list`), which is a different code path from the client-queue FIFO ordering already covered by `tests/libgearman-1.0/fifo.cc`. The two tests are complementary, not redundant — neither previously exercised the other's path.

Fixes #464

## Test plan

- [x] `./t/client --collection='gearman_execute_partition()'` passes
- [x] `./t/client --collection=fifo` still passes