### PR TITLE
docs: document global job priority behavior

### DIFF
--- a/PROTOCOL
+++ b/PROTOCOL
@@ -176,7 +176,9 @@ SUBMIT_JOB_LOW, SUBMIT_JOB_LOW_BG
     The Gearman job server queue is implemented with three levels:
     normal, high, and low. Jobs submitted with one of the HIGH versions
     always take precedence, and jobs submitted with the normal versions
-    take precedence over the LOW versions.
+    take precedence over the LOW versions. Priority is applied globally
+    across registered functions, so a high-priority job for any function
+    is assigned before normal- or low-priority jobs for other functions.
 
     The unique ID can be used by the server to reduce queue length. If a
     job with the same Unique ID has already been submitted, the server
@@ -573,6 +575,10 @@ prioritystatus
     - Number of queued normal priority jobs.
     - Number of queued low priority jobs.
     - Available workers registered for this function.
+
+    These counts are reported per function. Job assignment priority is still
+    global across registered functions: high-priority jobs are considered
+    before normal- or low-priority jobs, regardless of function name.
 
     Arguments:
     - None.

--- a/docs/source/bin/gearman.rst
+++ b/docs/source/bin/gearman.rst
@@ -59,6 +59,10 @@ SYNOPSIS
 
    Run jobs as low priority
 
+   Job assignment priority is global across registered functions: a high
+   priority job for any function is assigned before normal or low priority jobs
+   for other functions.
+
 .. option:: -P
 
    Prefix all output lines with functions names

--- a/docs/source/gearmand.rst
+++ b/docs/source/gearmand.rst
@@ -257,6 +257,10 @@ The following headers can be passed to change the behavior of the job::
    * X-Gearman-Unique: <unique key>
    * X-Gearman-Background: true
    * X-Gearman-Priority: <high|low>
+
+Job assignment priority is global across registered functions. A high priority
+job for any function is assigned before normal or low priority jobs for other
+functions.
    
 For example, to run a low priority background job, the following request can be sent::
 

--- a/docs/source/libgearman/gearman_client_add_task.rst
+++ b/docs/source/libgearman/gearman_client_add_task.rst
@@ -26,6 +26,10 @@ If the unique value is not set, then a unique will be assigned.
 
 :c:func:`gearman_client_add_task_high` and :c:func:`gearman_client_add_task_low` are identical to :c:func:`gearman_client_do`, only they set the priority to either high or low. 
 
+Job assignment priority is global across registered functions. A high priority
+job for any function is assigned before normal or low priority jobs for other
+functions.
+
 ------------
 RETURN VALUE
 ------------

--- a/docs/source/libgearman/gearman_client_add_task_background.rst
+++ b/docs/source/libgearman/gearman_client_add_task_background.rst
@@ -28,6 +28,10 @@ If the unique value is not set, then a unique will be assigned.
 identical to :c:func:`gearman_client_do`, only they set the priority to
 either high or low. 
 
+Job assignment priority is global across registered functions. A high priority
+job for any function is assigned before normal or low priority jobs for other
+functions.
+
 .. warning:: 
 
   You may wish to avoid using :c:func:`gearman_client_add_task_background` with a stack based allocated
@@ -51,4 +55,3 @@ To find out more information please check:
 .. seealso::
 
    :manpage:`gearmand(8)` :manpage:`libgearman(3)` :manpage:`gearman_task_st`
-

--- a/docs/source/libgearman/gearman_client_do.rst
+++ b/docs/source/libgearman/gearman_client_do.rst
@@ -31,6 +31,10 @@ server and waits for a reply.
 identical to :c:func:`gearman_client_do`, only they set the priority to
 either high or low. 
 
+Job assignment priority is global across registered functions. A high priority
+job for any function is assigned before normal or low priority jobs for other
+functions.
+
 All of the functions will block until either a response or an error is
 returned.
 

--- a/docs/source/libgearman/gearman_client_do_background.rst
+++ b/docs/source/libgearman/gearman_client_do_background.rst
@@ -30,6 +30,10 @@ gearmand server and returns the status via :c:type:`gearman_return_t`.
 :c:func:`gearman_client_add_task_high_background` and :c:func:`gearman_client_add_task_low_background` are identical to
 :c:func:`gearman_client_do_background`, only they set the :c:type:`gearman_priority_t` to either high or low. 
 
+Job assignment priority is global across registered functions. A high priority
+job for any function is assigned before normal or low priority jobs for other
+functions.
+
 
 If job_handle is not NULL, it will be populated with the name of the job_handle
 for the task created. The job handle needs to be the size of
@@ -60,4 +64,3 @@ To find out more information please check:
 
 .. seealso::
   :manpage:`gearmand(8)` :manpage:`libgearman(3)` :manpage:`gearman_strerror(3)`
-

--- a/docs/source/libgearman/gearman_task_attr_t.rst
+++ b/docs/source/libgearman/gearman_task_attr_t.rst
@@ -28,6 +28,10 @@ DESCRIPTION
 
 :c:func:`gearman_work` creates a :c:type:`gearman_work_t` with a priority.
 
+Job assignment priority is global across registered functions. A high priority
+job for any function is assigned before normal or low priority jobs for other
+functions.
+
 :c:func:`gearman_work_epoch` creates a :c:type:`gearman_work_t` which tells :c:func:`gearman_execute` to execute the workload at the time specified by epoch.
 
 :c:func:`gearman_work_background` creates a :c:type:`gearman_work_t` which tells :c:func:`gearman_execute` to execute the workload as a background job.

--- a/docs/source/protocol/text.rst
+++ b/docs/source/protocol/text.rst
@@ -54,3 +54,6 @@ The following list represents the current list of commands supported. You can is
 
    Queued jobs status by priority.
 
+   Counts are reported per function. Job assignment priority is global across
+   registered functions: high priority jobs are considered before normal or low
+   priority jobs, regardless of function name.


### PR DESCRIPTION
## Summary

Document that job assignment priority is global across registered functions/queues after the recent priority-selection change.

This updates the protocol reference and the user-facing CLI, HTTP, and libgearman priority documentation so readers do not infer that priority is only applied within each function.

Fixes #465.

## Verification

- `git diff --check`
- Inspected current `gearman_server_job_take()` implementation and priority regression coverage

Note: I could not run a Sphinx documentation build in this environment because the local Python environment does not have the `sphinx` module installed.