### PR TITLE
Prepare example Dockerfile for 2.0.0 release

### DIFF
--- a/docker/example/gearmand/Dockerfile
+++ b/docker/example/gearmand/Dockerfile
@@ -1,6 +1,6 @@
 FROM gearmand/supervisord:1.0
 
-ARG version=1.1.22
+ARG version=2.0.0
 
 LABEL description="Gearman Job Server Image"
 LABEL maintainer="Gearmand Developers https://github.com/gearman/gearmand"

--- a/docker/example/gearmand/Dockerfile
+++ b/docker/example/gearmand/Dockerfile
@@ -21,14 +21,14 @@ RUN apt-get update \
         libssl-dev \
         libtokyocabinet-dev \
         uuid-dev \
-        wget \
+        curl \
  && apt-get clean autoclean \
  && apt-get -y autoremove \
  && rm -rf /var/lib/apt/lists/*
 
 # Retrieve the source code and untar
 WORKDIR /var/lib/gearman
-RUN wget https://github.com/gearman/gearmand/releases/download/${version}/gearmand-${version}.tar.gz \
+RUN curl -f -L -O https://github.com/gearman/gearmand/releases/download/${version}/gearmand-${version}.tar.gz \
  && tar xzvf gearmand-${version}.tar.gz \
  && rm -f gearmand-${version}.tar.gz
 

--- a/docker/example/gearmand/Makefile
+++ b/docker/example/gearmand/Makefile
@@ -1,5 +1,5 @@
 IMAGE_NAME = gearmand
-IMAGE_VERSION = 1.1.22
+IMAGE_VERSION = 2.0.0
 USE_CACHE ?=
 
 image:


### PR DESCRIPTION
Update Dockerfile example for 2.0.0 release and switch it from using wget to curl (for more  thorough testing).