### PR TITLE
Fix data race in round_robin --job-retries test

### DIFF
--- a/tests/round_robin.cc
+++ b/tests/round_robin.cc
@@ -336,6 +336,13 @@ static test_return_t _job_retry_TEST(Context *context, Limit& limit)
                               NULL, 0, // workload
                               NULL, // result size
                               &rc));
+
+  // Join the background worker thread before inspecting limit's counters:
+  // job_retry_WORKER (running on that thread) writes limit->_count with no
+  // synchronization, so reading it here without a join first is a data race
+  // (and can observe a stale/torn value if the worker is still mid-retry).
+  handle->shutdown();
+
   ASSERT_EQ(uint32_t(limit.expected()), uint32_t(limit.count()));
   ASSERT_EQ(limit.response(), rc);
 


### PR DESCRIPTION
## Summary

Fixes #469 — the intermittent `t/round_robin` failure on
`round_robin.--job-retries=10.GEARMAN_FATAL`
(`Assertion 'uint32_t(limit.expected())' != 'uint32_t(limit.count())'`).

This is a bug in the **test**, not in gearmand itself. `_job_retry_TEST()`
(`tests/round_robin.cc`) starts the worker on a background thread via
`test_worker_start()`, then reads `limit.count()` / `limit.expected()` for
its assertions immediately after `gearman_client_do()` returns — without
ever joining that background thread first. The worker thread can still be
executing `job_retry_WORKER()` (which writes `limit->_count`) at that exact
moment, racing the main thread's read with no mutex, atomic, or join tying
the two together.

ThreadSanitizer confirms this directly: 29 of 30 runs of the
`--job-retries=10` collection reported

```
WARNING: ThreadSanitizer: data race
  Read of size 4 by main thread:
    Limit::count() tests/round_robin.cc:272
    _job_retry_TEST tests/round_robin.cc:339
  Previous write of size 4 by thread T2:
    Limit::increment() tests/round_robin.cc:262
    job_retry_WORKER tests/round_robin.cc:315
```

which lines up exactly with the intermittent CI failure.

## Fix

Call `handle->shutdown()` (which signals and joins the worker thread)
before checking the counters — the same pattern already used a little
further up in this file, in `round_robin_epoch_does_not_block_regular_TEST()`.

## Test plan

- [x] Built with `-fsanitize=thread`; ran the `--job-retries=10` collection
      30x before the fix — 29/30 runs hit the data race.
- [x] Same build, 50x after the fix — 0/50 races, 0 failures.
- [x] Normal (non-TSan) build, 10x — 0 failures.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>