### PR TITLE
Fix port-reservation race in libtest::Server::start()

### DIFF
--- a/libtest/port.cc
+++ b/libtest/port.cc
@@ -232,7 +232,11 @@ in_port_t get_free_port()
   }
 
   all_socket_fd.last_port= ret_port;
-  release_port(ret_port);
+
+  // Deliberately leave the reservation socket bound (not released) so the
+  // port stays unavailable to other processes' get_free_port() calls until
+  // the caller explicitly release_port()s it, e.g. once its server is
+  // confirmed listening. See libtest::Server::start().
 
   return ret_port;
 }

--- a/libtest/server.cc
+++ b/libtest/server.cc
@@ -229,6 +229,15 @@ bool Server::start()
                                 hostname(), port(), "Could not build command()");
   }
 
+  // Hold the port reservation (acquired via get_free_port()) until start()
+  // returns by any path -- success, ping timeout, or exception -- so no
+  // other concurrently-running test process's get_free_port() can grab
+  // _port while this server is still starting up.
+  struct PortReservation {
+    in_port_t port;
+    ~PortReservation() { libtest::release_port(port); }
+  } port_reservation{_port};
+
   Application::error_t ret;
   if (Application::SUCCESS !=  (ret= _app.run()))
   {
@@ -303,12 +312,6 @@ bool Server::start()
       libtest::dream(this_wait, 0);
     }
   }
-
-  // Only now that the server has either bound the port (ping succeeded) or
-  // definitively failed to start do we give up the reservation; releasing it
-  // any earlier reopens the port to other concurrently-running test
-  // processes' get_free_port() calls before this server has actually bound it.
-  libtest::release_port(_port);
 
   if (pinged == false)
   {

--- a/libtest/server.cc
+++ b/libtest/server.cc
@@ -229,8 +229,6 @@ bool Server::start()
                                 hostname(), port(), "Could not build command()");
   }
 
-  libtest::release_port(_port);
-
   Application::error_t ret;
   if (Application::SUCCESS !=  (ret= _app.run()))
   {
@@ -305,6 +303,12 @@ bool Server::start()
       libtest::dream(this_wait, 0);
     }
   }
+
+  // Only now that the server has either bound the port (ping succeeded) or
+  // definitively failed to start do we give up the reservation; releasing it
+  // any earlier reopens the port to other concurrently-running test
+  // processes' get_free_port() calls before this server has actually bound it.
+  libtest::release_port(_port);
 
   if (pinged == false)
   {


### PR DESCRIPTION
## Summary

- `get_free_port()` in `libtest/port.cc` released its reservation socket immediately, before even returning the port number to the caller — so the "reservation" only protected a handful of lines inside `get_free_port()` itself, not the much longer window until the server actually binds.
- The `release_port(_port)` call in `Server::start()` (previously right before `_app.run()`) was consequently a no-op, since the socket had already been closed by `get_free_port()` well before that point.
- This left the port free for any other concurrently-running test process's `get_free_port()` to grab during the fork/exec/bind window, causing the intermittent, victim-of-the-week CI failures described in #471 (`t/vector`, `t/protocol`, `t/worker`, etc., all unrelated to round_robin/#469/#470).

## Fix

- `get_free_port()` no longer releases its own reservation — it stays bound (not `listen()`ing) until the caller explicitly calls `release_port()`.
- `Server::start()` moved the `release_port(_port)` call from right before `_app.run()` to right after the ping loop confirms the child is listening (or has definitively failed to start), closing the real race window.

This works because both the reservation socket and the real server's listening socket (e.g. gearmand, see `libgearman-server/gearmand.cc`) set `SO_REUSEADDR`, and the reservation socket never calls `listen()` — so Linux allows the real bind to the exact port to succeed while the reservation is still held, while still blocking *other* processes' `get_free_port()` autoassignment from picking the same port during the vulnerable startup window.

Fixes #471

## Test plan

- [x] `make` builds clean
- [x] `t/unittest` passes (including `get_free_port()`/`default_port()` checks)
- [x] `t/cycle` passes, including the explicit bind-conflict test (still correctly detects a real port conflict)
- [x] `t/protocol`, `t/round_robin`, `t/worker`, `t/vector` pass individually
- [x] Stress test: 8 concurrent `t/protocol` runs, and 16 concurrent mixed runs (`t/protocol`/`t/worker`/`t/round_robin`/`t/vector`) to simulate `make check -j` contention — no failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)