### PR TITLE
Release get_free_port() reservations not tied to a Server's primary port

### DIFF
--- a/libtest/unittest.cc
+++ b/libtest/unittest.cc
@@ -921,8 +921,21 @@ static test_return_t get_free_port_TEST(void *)
 {
   in_port_t ret_port;
   ASSERT_TRUE((ret_port= get_free_port()));
-  ASSERT_TRUE(get_free_port() != default_port());
-  ASSERT_TRUE(get_free_port() != get_free_port());
+
+  in_port_t second_port= get_free_port();
+  ASSERT_TRUE(second_port != default_port());
+
+  in_port_t third_port= get_free_port();
+  in_port_t fourth_port= get_free_port();
+  ASSERT_TRUE(third_port != fourth_port);
+
+  // These are throwaway reservations never tied to a Server, so release them
+  // ourselves; default_port()'s own reservation is intentionally left alone
+  // since it stays valid for the lifetime of the process.
+  release_port(ret_port);
+  release_port(second_port);
+  release_port(third_port);
+  release_port(fourth_port);
 
   return TEST_SUCCESS;
 }

--- a/tests/context.h
+++ b/tests/context.h
@@ -66,6 +66,7 @@ public:
   {
     extra_clear();
     _servers.clear();
+    libtest::release_port(_port);
   }
 
   const char *worker_function_name() const
@@ -123,6 +124,7 @@ public:
 
     _worker= NULL;
     extra_clear();
+    libtest::release_port(_port);
     _port= get_free_port();
   }
 };

--- a/tests/cycle.cc
+++ b/tests/cycle.cc
@@ -56,9 +56,15 @@ struct cycle_context_st
     reset();
   }
 
+  ~cycle_context_st()
+  {
+    libtest::release_port(port);
+  }
+
   void reset()
   {
     servers.clear();
+    libtest::release_port(port);
     port= get_free_port();
   }
 

--- a/tests/gearmand.cc
+++ b/tests/gearmand.cc
@@ -191,6 +191,10 @@ static test_return_t long_keepalive_start_TEST(void *)
   char port_str[1024];
   ASSERT_TRUE(snprintf(port_str, sizeof(port_str), "--port=%d", int32_t(port)) > 0);
 
+  // --check-args only validates arguments; gearmand never binds this port,
+  // so there's nothing for anyone else to release it later.
+  libtest::release_port(port);
+
   const char *args[]= {
     port_str,
     "--check-args",
@@ -549,6 +553,10 @@ static test_return_t config_file_SIMPLE_TEST(void *)
   in_port_t port= libtest::get_free_port();
   char port_str[1024];
   ASSERT_TRUE(snprintf(port_str, sizeof(port_str), "%d", int32_t(port)) > 0);
+
+  // --check-args only validates the config file; gearmand never binds this
+  // port, so there's nothing for anyone else to release it later.
+  libtest::release_port(port);
 
   std::string config_file= "etc/gearmand.conf";
   {

--- a/tests/httpd_test.cc
+++ b/tests/httpd_test.cc
@@ -154,7 +154,13 @@ static void *world_create(server_startup_st& servers, test_return_t& error)
   length= snprintf(buffer, sizeof(buffer), "--http-port=%d", int(http_port));
   fatal_assert(length > 0 and sizeof(length) < sizeof(buffer));
   const char *argv[]= { "--protocol=http", buffer, 0 };
-  if (server_startup(servers, "gearmand", libtest::default_port(), argv) == false)
+  bool started= server_startup(servers, "gearmand", libtest::default_port(), argv);
+
+  // http_port is only ever used as the --http-port= value above; it's never
+  // the primary port of a Server object, so nothing else will release it.
+  libtest::release_port(http_port);
+
+  if (started == false)
   {
     error= TEST_SKIPPED;
     return NULL;

--- a/tests/round_robin.cc
+++ b/tests/round_robin.cc
@@ -59,12 +59,14 @@ struct Context
 
   ~Context()
   {
-    reset();
+    servers.clear();
+    libtest::release_port(_port);
   }
 
   void reset()
   {
     servers.clear();
+    libtest::release_port(_port);
     _port= libtest::get_free_port();
     _retries= 0;
   }


### PR DESCRIPTION
## Summary

#472 fixed the primary port-reservation race in `libtest::Server::start()`: `get_free_port()` now keeps its reservation socket bound until `release_port()` is called, and `Server::start()` releases its own `_port` once the server is confirmed up (or definitively failed).

That fix only releases the `Server`'s own `_port`. Several call sites reserve a port for something other than a `Server` object's primary port and never released it — the reservation socket now leaks (stays bound) for the rest of that test binary's process lifetime:

- `tests/context.h`'s `Context`, `tests/cycle.cc`'s `cycle_context_st`, and `tests/round_robin.cc`'s `Context` all overwrite their stored port in `reset()` with a fresh `get_free_port()` value without releasing the old one first, and never released the final port on destruction.
- `tests/httpd_test.cc` reserves `http_port`, passed only as `--http-port=` to a gearmand instance whose own primary port is `default_port()` — the `Server` never knows about `http_port`.
- `tests/gearmand.cc`'s `long_keepalive_start_TEST` and `config_file_SIMPLE_TEST` reserve a port for `--check-args` validation runs that never actually bind it (no `Server` involved at all).
- `libtest/unittest.cc`'s `get_free_port_TEST` exercises `get_free_port()` directly and never releases what it reserves.

## Fix

Release the port explicitly wherever the above patterns discard/overwrite/finish with a reservation:

- `reset()`-style methods now call `release_port()` on the *old* port before generating a new one; destructors now release the *current* port directly instead of wastefully fetching a new one just to abandon it (`round_robin.cc`'s destructor previously called `reset()`, which did exactly that).
- `httpd_test.cc` releases `http_port` right after `server_startup()` returns (success or failure) — by then gearmand has either bound it or failed outright.
- `gearmand.cc`'s two `--check-args` tests release the port immediately after formatting it into the CLI/config argument, since `--check-args` never binds.
- `get_free_port_TEST` releases each of its throwaway reservations at the end.

`default_port()`'s single process-wide reservation is intentionally left untouched — callers throughout the test suite rely on it staying valid for the whole process lifetime, so releasing it would be a behavior change, not a leak fix.

## Test plan

- [x] Full rebuild of all affected binaries (`t/unittest`, `t/cycle`, `t/round_robin`, `t/gearmand`, `t/httpd`, plus everything else that includes `tests/context.h`: `t/drizzle`, `t/memcached`, `t/redis`, `t/mysql`, `t/tokyocabinet`, `t/postgres`, `t/ephemeral`) — all compile clean.
- [x] Ran every affected binary individually — all pass (backends without a local install, e.g. drizzle/memcached/mysql/postgres, skip as expected; `t/unittest`'s only failures are pre-existing environment artifacts unrelated to this change — `getenv()` checks that only pass under `make check`'s harness, and a `/bin/echo`-path issue specific to this NixOS dev machine).
- [x] Compared 4x-concurrent `t/cycle` and a heavier 16-way mix (`protocol`/`worker`/`round_robin`/`cycle`) against the pre-fix baseline on the same machine: an occasional `t/cycle` flake under the heaviest combination reproduces identically with or without this change, confirming it's pre-existing high-load contention in this environment, not a regression from this PR.

Fixes #474

🤖 Generated with [Claude Code](https://claude.com/claude-code)