### PR TITLE
Guard gearman_log_error() against NULL error strings

### DIFF
--- a/libgearman/log.cc
+++ b/libgearman/log.cc
@@ -79,7 +79,10 @@ void gearman_log_error(gearman_universal_st& state, gearman_verbose_t verbose)
   {
     if (state.log_fn)
     {
-      state.log_fn(state.error(), verbose, state.log_context);
+      if (const char *line= state.error())
+      {
+        state.log_fn(line, verbose, state.log_context);
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- `gearman_universal_st::error()` returns `nullptr` when the error code is `GEARMAN_SUCCESS`, but `gearman_log_error()` (libgearman/log.cc) passed that value straight to the user-supplied `log_fn` callback without a NULL check.
- Every other logging path in the file (`gearman_log`, `_info`, `_debug`) formats into a local buffer via `vsnprintf` and can therefore never hand `log_fn` a NULL pointer — `gearman_log_error` was the one path that could crash a `log_fn` implementation that assumes a valid string (e.g. `strlen`/`fprintf("%s", line)`).
- None of the current callers (all in `error.cc`) trigger this today since they always set a real error code first, but it's a latent footgun for any future or embedder call path.

## Test plan
- [x] Build passes (`configure && make`)
- [x] Existing libgearman test suite passes