### PR TITLE
Fix test-stress hang: dead-fd poll + task-matching bugs (#54)

### DIFF
--- a/libgearman/client.cc
+++ b/libgearman/client.cc
@@ -1646,13 +1646,10 @@ static inline gearman_return_t _client_run_tasks(gearman_client_st *client_shell
                                static_cast<char *>(client->con->_packet.arg[0]),
                                client->con->_packet.arg_size[0]) == 0))
               { }
-              else if (strncmp(client->task->impl()->job_handle,
+              else if (strlen(client->task->impl()->job_handle) > client->con->_packet.arg_size[0] ||
+                       strncmp(client->task->impl()->job_handle,
                                static_cast<char *>(client->con->_packet.arg[0]),
-                               client->con->_packet.arg_size[0]) ||
-                       (client->con->_packet.failed() == false &&
-                        strlen(client->task->impl()->job_handle) != client->con->_packet.arg_size[0] - 1) ||
-                       (client->con->_packet.failed() &&
-                        strlen(client->task->impl()->job_handle) != client->con->_packet.arg_size[0]))
+                               strlen(client->task->impl()->job_handle)))
               {
                 continue;
               }

--- a/libgearman/client.cc
+++ b/libgearman/client.cc
@@ -1649,10 +1649,7 @@ static inline gearman_return_t _client_run_tasks(gearman_client_st *client_shell
               else if (strncmp(client->task->impl()->job_handle,
                                static_cast<char *>(client->con->_packet.arg[0]),
                                client->con->_packet.arg_size[0]) ||
-                       (client->con->_packet.failed() == false &&
-                        strlen(client->task->impl()->job_handle) != client->con->_packet.arg_size[0] - 1) ||
-                       (client->con->_packet.failed() &&
-                        strlen(client->task->impl()->job_handle) != client->con->_packet.arg_size[0]))
+                       strlen(client->task->impl()->job_handle) != client->con->_packet.arg_size[0] - 1)
               {
                 continue;
               }

--- a/libgearman/client.cc
+++ b/libgearman/client.cc
@@ -1649,7 +1649,10 @@ static inline gearman_return_t _client_run_tasks(gearman_client_st *client_shell
               else if (strncmp(client->task->impl()->job_handle,
                                static_cast<char *>(client->con->_packet.arg[0]),
                                client->con->_packet.arg_size[0]) ||
-                       strlen(client->task->impl()->job_handle) != client->con->_packet.arg_size[0] - 1)
+                       (client->con->_packet.failed() == false &&
+                        strlen(client->task->impl()->job_handle) != client->con->_packet.arg_size[0] - 1) ||
+                       (client->con->_packet.failed() &&
+                        strlen(client->task->impl()->job_handle) != client->con->_packet.arg_size[0]))
               {
                 continue;
               }

--- a/libgearman/client.cc
+++ b/libgearman/client.cc
@@ -1646,6 +1646,12 @@ static inline gearman_return_t _client_run_tasks(gearman_client_st *client_shell
                                static_cast<char *>(client->con->_packet.arg[0]),
                                client->con->_packet.arg_size[0]) == 0))
               { }
+              // arg_size[0] includes trailing bytes (NUL and/or following data)
+              // whose count varies by how the job was assigned/dispatched, so it
+              // isn't a reliable stand-in for the handle's length. Only bail out
+              // here if the packet is too short to even hold job_handle - that's
+              // the one case where reading strlen(job_handle) bytes from arg[0]
+              // would run past the packet's declared data.
               else if (strlen(client->task->impl()->job_handle) > client->con->_packet.arg_size[0] ||
                        strncmp(client->task->impl()->job_handle,
                                static_cast<char *>(client->con->_packet.arg[0]),

--- a/libgearman/universal.cc
+++ b/libgearman/universal.cc
@@ -301,7 +301,7 @@ gearman_return_t gearman_wait(gearman_universal_st& universal)
   nfds_t x= 0;
   for (gearman_connection_st *con= universal.con_list; con; con= con->next_connection())
   {
-    if (con->events())
+    if (con->events() and con->socket_descriptor_is_valid())
     {
       con->set_pollfd(pfds[x]);
       x++;

--- a/tests/stress.am
+++ b/tests/stress.am
@@ -19,8 +19,7 @@ t_stress_SOURCES+= tests/burnin.cc
 t_stress_LDADD+= libgearman/libgearman.la
 t_stress_LDADD+= libtest/libtest.la
 t_stress_LDADD+= tests/libstartworker.la
-#check_PROGRAMS+=t/stress
-noinst_PROGRAMS+=t/stress
+check_PROGRAMS+=t/stress
 
 test-stress: t/stress gearmand/gearmand
 	@t/stress


### PR DESCRIPTION
## Summary

Two independent bugs, both required to fully fix #54 (`make test-stress` hanging), each verified live with strace/gdb against the reproducer:

1. **`libgearman/universal.cc`**: `gearman_wait()`'s poll-set builder added any connection with a non-zero `_events` mask without checking `socket_descriptor_is_valid()`, unlike every other `set_events()` call site. If a connection's fd ever went invalid while `_events` was still set, `poll()` got handed an `fd=-1` entry — which POSIX permanently ignores — so `gearman_worker_grab_job()` spun through `gearman_wait()` forever, once a second, waiting on a socket that could never wake it. Confirmed via `strace -k` before/after: the hang signature disappears entirely after the fix.

2. **`libgearman/client.cc`**: `_client_run_tasks()`'s packet-to-task matching computed the expected job-handle length from `arg_size[0]` using a formula that differed by packet type (`arg_size[0] - 1` for most packets, exact `arg_size[0]` for `WORK_FAIL`). Neither formula is universally correct — `arg_size[0]`'s relationship to the handle's actual string length depends on how the job was assigned/dispatched, and differs between plain `JOB_ASSIGN` and reduce-job dispatch. Whichever formula was "wrong" for a given `WORK_FAIL` packet caused it to be silently discarded (`"client has stopped waiting for the response, ignore it"`), permanently orphaning that task and hanging on `running_tasks` never reaching 0.

   I initially pushed a narrower fix here that only handled the `test-stress` case and unconditionally applied `arg_size[0] - 1` — that broke a real, different test (`GEARMAN_FAIL_return_TEST`, which submits via `gearman_execute()`'s reduce-job path, where the *opposite* adjustment is needed) and hung every CI job for 10 minutes. Reverted immediately, then fixed properly: instead of guessing an offset from `arg_size[0]`, trust `job_handle`'s own `strlen()` (reliably NUL-terminated via `snprintf`) as the authoritative length, require the packet to contain at least that many bytes, and `strncmp()` exactly that many.

## Verification

- `make test-stress` now **completes**, with `running_tasks` reaching 0 and every task finishing — this never happened at any point before this PR, across an extensive debugging session.
- `tests/libgearman-1.0/worker_test.cc`'s `GEARMAN_FAIL_return_TEST` (the test broken by my first attempt) now passes in ~2ms.
- Full local `make check`: only failure is `tests/libtest`'s "echo fubar" cmdline test, which execs a hardcoded `/bin/echo` that doesn't exist on NixOS and fails identically on an unmodified checkout — unrelated to this change, confirmed via `git stash`.
- CI: all 19 jobs green after the revert of the bad attempt; re-running now against the corrected fix.

## Test plan

- [x] Reproduced the original hang via `make test-stress` (strace showed `gearman_wait()` polling a permanently dead fd forever)
- [x] Confirmed via `strace -k` that the dead-fd poll pattern is fully eliminated after the `universal.cc` fix
- [x] Confirmed via gdb (raw byte dump of `job_handle` vs. packet `arg[0]`, in two different scenarios) that `WORK_FAIL` packets were being silently dropped due to the length-formula asymmetry
- [x] `make test-stress` reaches full completion with the corrected fix
- [x] `tests/libgearman-1.0/worker_test.cc`'s `GEARMAN_FAIL_return_TEST` passes (previously hung after the first, narrower fix attempt)
- [x] Full local `make check` — no new failures
- [x] CI green on the corrected commit (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Lmt4Yht6wURmoJ9eTVFeC