### PR TITLE
Support compiling with clang and add clang builds to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,11 @@ jobs:
           - {name: 'ubuntu-22.04 gcc-12', os: ubuntu-22.04, cc: 'gcc-12', cxx: 'g++-12', tag: '12'}
           - {name: 'ubuntu-24.04 gcc-13', os: ubuntu-24.04, cc: 'gcc-13', cxx: 'g++-13', tag: '13'}
           - {name: 'ubuntu-24.04 gcc-14', os: ubuntu-24.04, cc: 'gcc-14', cxx: 'g++-14', tag: '14'}
+          - {name: 'ubuntu-24.04 clang-20', os: ubuntu-24.04, cc: 'clang-20', cxx: 'clang++-20', tag: '20'}
           - {name: 'ubuntu-25.04 gcc-15', os: ubuntu-latest, container: 'ubuntu:25.04', cc: 'gcc-15', cxx: 'g++-15', tag: '15', toolchain: 'ppa:ubuntu-toolchain-r/test'}
           - {name: 'ubuntu-25.10 gcc-15', os: ubuntu-latest, container: 'ubuntu:25.10', cc: 'gcc-15', cxx: 'g++-15', tag: '15'}
           - {name: 'ubuntu-26.04 gcc-16', os: ubuntu-latest, container: 'ubuntu:26.04', cc: 'gcc-16', cxx: 'g++-16', tag: '16'}
+          - {name: 'ubuntu-26.04 clang-22', os: ubuntu-latest, container: 'ubuntu:26.04', cc: 'clang-22', cxx: 'clang++-22', extra_packages: 'libstdc++-16-dev', tag: '22'} # libstdc++-16-dev headers are required for clang-22 builds; libstdc++ version may shift in the future
           - {name: 'alpine-3.18 gcc-12', os: ubuntu-latest, container: 'alpine:3.18', cc: 'gcc', cxx: 'g++', tag: '12'}
           - {name: 'alpine-3.19 gcc-13', os: ubuntu-latest, container: 'alpine:3.19', cc: 'gcc', cxx: 'g++', tag: '13'}
           - {name: 'alpine-3.20 gcc-13', os: ubuntu-latest, container: 'alpine:3.20', cc: 'gcc', cxx: 'g++', tag: '13'}
@@ -139,7 +141,7 @@ jobs:
       run: |
            case "${GHA_CONFIG_NAME}" in
               ubuntu*)
-                 sudo apt-get update && sudo apt-get -o Acquire::Retries=3 install -y libboost-all-dev gperf libevent-dev uuid-dev sphinx-doc sphinx-common libhiredis-dev curl ${{ matrix.config.cc }} ${{ matrix.config.cxx }}
+                 sudo apt-get update && sudo apt-get -o Acquire::Retries=3 install -y libboost-all-dev gperf libevent-dev uuid-dev sphinx-doc sphinx-common libhiredis-dev curl ${{ matrix.config.cc }} ${{ matrix.config.cxx }} ${{ matrix.config.extra_packages }}
                  ;;
               *)
                  ;;

--- a/docker/testing/ubuntu/26.04-clang22/.dockerignore
+++ b/docker/testing/ubuntu/26.04-clang22/.dockerignore
@@ -1,0 +1,3 @@
+.dockerignore
+Dockerfile
+Makefile

--- a/docker/testing/ubuntu/26.04-clang22/Dockerfile
+++ b/docker/testing/ubuntu/26.04-clang22/Dockerfile
@@ -1,0 +1,56 @@
+ARG version=26.04
+FROM ubuntu:${version}
+
+ARG version
+ARG GEARMAN_REPO=https://github.com/gearman/gearmand
+
+LABEL description="Gearman Job Server Image (Ubuntu ${version}/clang-22)"
+LABEL maintainer="Gearmand Developers https://github.com/gearman/gearmand"
+LABEL version="https://github.com/gearman/gearmand/tree/master Ubuntu ${version}/clang-22"
+
+# Configure environment
+ENV DEBIAN_FRONTEND=noninteractive \
+    HOME=/root
+
+# Install packages
+RUN apt-get update \
+ && apt-get -y upgrade \
+ && apt-get -y install \
+	automake \
+	autoconf \
+	libtool \
+	make \
+	curl \
+	clang-22 \
+	clang++-22 \
+	libstdc++-16-dev \
+	git \
+	gperf \
+	libssl-dev \
+	libboost-all-dev \
+	libevent-dev \
+	libhiredis-dev \
+	libpq-dev \
+	libtokyocabinet-dev \
+	tcsh \
+	python3-sphinx \
+	uuid-dev \
+	wget \
+ && apt-get clean autoclean \
+ && apt-get -y autoremove \
+ && rm -rf /var/lib/apt/lists/*
+
+# Switch to a non-root user
+RUN adduser --no-create-home --disabled-password --gecos '' --shell /bin/bash gearman
+USER gearman
+
+# Clone the GitHub repository master branch
+ENV HOME=/tmp
+RUN cd /tmp && git clone --depth 1 --branch master ${GEARMAN_REPO}.git
+
+# Bootstrap, configure, make, and make test
+WORKDIR /tmp/gearmand
+RUN ./bootstrap.sh -a
+RUN env CC=clang-22 CXX=clang++-22 ./configure --enable-ssl 2>&1 | tee ./configure.log
+RUN make 2>&1 | tee ./build.log
+RUN make test 2>&1 | tee ./test.log

--- a/docker/testing/ubuntu/26.04-clang22/Makefile
+++ b/docker/testing/ubuntu/26.04-clang22/Makefile
@@ -1,0 +1,12 @@
+IMAGE_NAME = gearmand-testing
+IMAGE_BASE = ubuntu
+IMAGE_VERSION = 26.04
+IMAGE_TAG = $(IMAGE_NAME)/${IMAGE_BASE}-clang22:$(IMAGE_VERSION)
+USE_CACHE ?=
+
+image:
+	@echo "Building Docker image ${IMAGE_TAG}..."
+	-docker build $(USE_CACHE) --network=host -t $(IMAGE_TAG) . && (docker images -q -f dangling=true | xargs --no-run-if-empty docker rmi)
+
+image-no-cache:
+	$(MAKE) -e USE_CACHE=--no-cache

--- a/libgearman-server/plugins/queue/redis/queue.cc
+++ b/libgearman-server/plugins/queue/redis/queue.cc
@@ -267,10 +267,10 @@ static size_t build_key(vchar_t &key,
                         size_t function_name_size)
 {
   size_t buf_size = function_name_size + unique_size + prefix_size + 4;
-  char buf[buf_size];
+  std::vector<char> buf(buf_size);
   // buf size is overestimated
   // so buf contains some \0 at the end
-  int key_size= snprintf(buf, buf_size, GEARMAND_KEY_LITERAL,
+  int key_size= snprintf(buf.data(), buf_size, GEARMAND_KEY_LITERAL,
                          prefix,
                          (int)function_name_size, function_name,
                          (int)unique_size, unique);
@@ -281,7 +281,7 @@ static size_t build_key(vchar_t &key,
   }
 
   // std::string removes all \0 at the end of buf
-  std::string s{buf};
+  std::string s{buf.data()};
 
   key.resize(0);
   std::copy(s.begin(), s.end(), std::back_inserter(key));


### PR DESCRIPTION
This adds clang-20 and clang-22 builds to the GitHub Actions CI workflow.

Clang does not like variable-length arrays and emits a warning which broke compilation of libgearman-server/plugins/queue/redis/queue.cc. This fixes that by changing the variable-length array to a std::vector instead. Similar changes were made years ago (IIRC), but this one slipped by previous efforts presumably because hiredis was not installed and compilation of the code was skipped at the time.