### PR TITLE
Fix get_free_port() byte order and close multi_client restart port race

### DIFF
--- a/libtest/port.cc
+++ b/libtest/port.cc
@@ -141,6 +141,57 @@ void release_port(in_port_t arg)
   all_socket_fd.release(arg);
 }
 
+bool reserve_port(in_port_t port)
+{
+  // Same trick get_free_port() uses to hold a port: bind (but never
+  // listen()) a SO_REUSEADDR socket to it. A real listener started later
+  // with SO_REUSEADDR on the same port (e.g. gearmand) can still bind
+  // alongside it, but other processes' get_free_port()/reserve_port() calls
+  // cannot claim the port while this socket is held open.
+  int retries= 10;
+
+  while (retries--)
+  {
+    int sd;
+    if ((sd= socket(AF_INET, SOCK_STREAM, 0)) == SOCKET_ERROR)
+    {
+      Error << strerror(errno);
+      return false;
+    }
+
+    int optval= 1;
+    if (setsockopt(sd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval)) == SOCKET_ERROR)
+    {
+      Error << strerror(errno);
+      close(sd);
+      return false;
+    }
+
+    struct sockaddr_in sin;
+    sin.sin_port= htons(port);
+    sin.sin_addr.s_addr= INADDR_ANY;
+    sin.sin_family= AF_INET;
+
+    if (bind(sd, (struct sockaddr *)&sin, sizeof(struct sockaddr_in)) != SOCKET_ERROR)
+    {
+      all_socket_fd._pair.push_back(std::make_pair(sd, port));
+      return true;
+    }
+
+    close(sd);
+
+    if (errno != EADDRINUSE)
+    {
+      Error << strerror(errno);
+      return false;
+    }
+
+    libtest::dream(2, 0);
+  }
+
+  return false;
+}
+
 in_port_t get_free_port()
 {
   const in_port_t default_port= in_port_t(-1);
@@ -171,7 +222,12 @@ in_port_t get_free_port()
 
             if (getsockname(sd, (struct sockaddr *)&sin, &addrlen) != -1)
             {
-              ret_port= sin.sin_port;
+              // sin_port is network byte order; every caller (gearmand's
+              // --port=, gearman_client_add_server(), etc.) treats the
+              // returned value as a plain host-order decimal port number,
+              // so it must be converted here or the port we hand out won't
+              // match the one this function actually verified and reserved.
+              ret_port= ntohs(sin.sin_port);
             }
           }
           else

--- a/libtest/port.h
+++ b/libtest/port.h
@@ -51,6 +51,9 @@ LIBTEST_API
 in_port_t get_free_port();
 
 LIBTEST_API
+bool reserve_port(in_port_t port);
+
+LIBTEST_API
 void release_port(in_port_t arg);
 
 } // namespace libtest

--- a/tests/libgearman-1.0/multi_client_test.cc
+++ b/tests/libgearman-1.0/multi_client_test.cc
@@ -106,6 +106,12 @@ static test_return_t multi_client_test(void *object)
   in_port_t gearmand_port_2= test_client->port(1);
   ASSERT_TRUE(server_container.shutdown(0));
 
+  // Server 1 is restarted on this same port further down, but not until
+  // after several job-status round trips below, so hold the port reserved
+  // for the whole gap -- otherwise a concurrently-running test process's
+  // get_free_port() could grab it first and the restart's bind() would fail.
+  libtest::reserve_port(gearmand_port_1);
+
   // Try to queue up a job again
   const char* unique_2= "unique_2";
   test_compare(GEARMAN_LOST_CONNECTION,
@@ -136,6 +142,10 @@ static test_return_t multi_client_test(void *object)
 
   // Bring server 1 back up
   server_container.shutdown();
+  // Server 2 was just killed too; reserve its port the same way for the
+  // same reason as gearmand_port_1 above. gearmand_port_1's reservation is
+  // still held from further up.
+  libtest::reserve_port(gearmand_port_2);
   ASSERT_TRUE(server_startup(server_container, "gearmand", gearmand_port_1, server_argv));
   ASSERT_TRUE(server_startup(server_container, "gearmand", gearmand_port_2, server_argv));
 


### PR DESCRIPTION
## Summary

- `libtest::get_free_port()` copied `sin_port` from `getsockname()` straight into the returned port with no `ntohs()`, so the port it reserved/reported differed from the one every caller (gearmand's `--port=`, `gearman_client_add_server()`, etc.) actually binds/connects to. This made the port-reservation fix from #471 (`1973c2ea`) protect the wrong port, leaving the real one exposed to collisions with other concurrently-running test processes under `make test -j5`.
- `tests/libgearman-1.0/multi_client_test.cc` kills a gearmand server mid-test and later restarts a new process on the exact same previously-used port (its clients are already configured for that host:port). That restart path never goes through `get_free_port()`, so the port sat completely unprotected between `kill()` and rebind.

Fixes both: `ntohs()` the port in `get_free_port()`, and add `libtest::reserve_port()` (same bind-without-listen `SO_REUSEADDR` trick) used by `multi_client_test.cc` to hold each port from kill through restart.

Full writeup: gearman/gearmand#479 (comment)

## Test plan

- [x] `t/multi_client` passes individually
- [x] `t/multi_client` passes run 6-way concurrently (previously the scenario that could trigger the race)
- [x] `get_free_port()`'s own unit tests (`t/unittest`) pass
- [x] Full `make test` shows no new failures beyond a pre-existing NixOS-only environment issue (`/bin/echo` not present) unrelated to this change

Fixes #479