### PR TITLE
Fix #28: decode real OpenSSL error instead of SSL_get_error()'s enum

### DIFF
--- a/libgearman-server/io.cc
+++ b/libgearman-server/io.cc
@@ -163,9 +163,15 @@ static size_t _connection_read(gearman_server_con_st *con, void *data, size_t da
         default:
           { // All other errors
             char errorString[SSL_ERROR_SIZE]= { 0 };
-            ERR_error_string_n(ssl_error, errorString, sizeof(errorString));
             ret= GEARMAND_LOST_CONNECTION;
-            gearmand_log_info(GEARMAN_DEFAULT_LOG_PARAM, "SSL failure(%s) errno:%d", errorString, errno);
+            if (gearman_ssl_error_string(errorString, sizeof(errorString)))
+            {
+              gearmand_log_info(GEARMAN_DEFAULT_LOG_PARAM, "SSL failure(%s)", errorString);
+            }
+            else
+            {
+              gearmand_log_info(GEARMAN_DEFAULT_LOG_PARAM, "Peer connection has called close() without a clean SSL shutdown");
+            }
             _connection_close(connection);
 
             return 0;
@@ -343,10 +349,14 @@ static gearmand_error_t _connection_flush(gearman_server_con_st *con)
             default:
               {
                 char errorString[SSL_ERROR_SIZE]= { 0 };
-                ERR_error_string_n(ssl_error, errorString, sizeof(errorString));
                 _connection_close(connection);
-                return gearmand_log_gerror(GEARMAN_DEFAULT_LOG_PARAM, GEARMAND_LOST_CONNECTION, "SSL failure(%s)",
-                                           errorString);
+                if (gearman_ssl_error_string(errorString, sizeof(errorString)))
+                {
+                  return gearmand_log_gerror(GEARMAN_DEFAULT_LOG_PARAM, GEARMAND_LOST_CONNECTION, "SSL failure(%s)",
+                                             errorString);
+                }
+                return gearmand_log_gerror(GEARMAN_DEFAULT_LOG_PARAM, GEARMAND_LOST_CONNECTION,
+                                           "Peer connection has called close() without a clean SSL shutdown");
               }
           }
         }

--- a/libgearman-server/plugins/protocol/gear/protocol.cc
+++ b/libgearman-server/plugins/protocol/gear/protocol.cc
@@ -395,9 +395,13 @@ static gearmand_error_t _gear_con_add(gearman_server_con_st *connection)
         default:
           {
             char ssl_error_buffer[SSL_ERROR_SIZE]= { 0 };
-            ERR_error_string_n(ssl_error, ssl_error_buffer, sizeof(ssl_error_buffer));
-            return gearmand_log_gerror(GEARMAN_DEFAULT_LOG_PARAM, GEARMAND_LOST_CONNECTION, "%s(%d)",
-                                       ssl_error_buffer, ssl_error);
+            if (gearman_ssl_error_string(ssl_error_buffer, sizeof(ssl_error_buffer)))
+            {
+              return gearmand_log_gerror(GEARMAN_DEFAULT_LOG_PARAM, GEARMAND_LOST_CONNECTION, "SSL_accept() failed: %s",
+                                         ssl_error_buffer);
+            }
+            return gearmand_log_gerror(GEARMAN_DEFAULT_LOG_PARAM, GEARMAND_LOST_CONNECTION,
+                                       "SSL_accept() failed: connection closed during handshake");
           }
       }
     }

--- a/libgearman/connection.cc
+++ b/libgearman/connection.cc
@@ -681,8 +681,11 @@ gearman_return_t gearman_connection_st::enable_ssl()
     {
       close_socket();
       char errorString[SSL_ERROR_SIZE]= { 0 };
-      ERR_error_string_n(SSL_get_error(_ssl, 0), errorString, sizeof(errorString));
-      return gearman_error(universal, GEARMAN_COULD_NOT_CONNECT, errorString);
+      if (gearman_ssl_error_string(errorString, sizeof(errorString)))
+      {
+        return gearman_error(universal, GEARMAN_COULD_NOT_CONNECT, errorString);
+      }
+      return gearman_error(universal, GEARMAN_COULD_NOT_CONNECT, "SSL_set_fd() failed");
     }
 
     SSL_set_connect_state(_ssl);
@@ -875,9 +878,13 @@ gearman_return_t gearman_connection_st::flush()
             default:
               {
                 char errorString[SSL_ERROR_SIZE]= { 0 };
-                ERR_error_string_n(ssl_error, errorString, sizeof(errorString));
                 close_socket();
-                return gearman_universal_set_error(universal, GEARMAN_LOST_CONNECTION, GEARMAN_AT, "SSL failure(%s)", errorString);
+                if (gearman_ssl_error_string(errorString, sizeof(errorString)))
+                {
+                  return gearman_universal_set_error(universal, GEARMAN_LOST_CONNECTION, GEARMAN_AT, "SSL failure(%s)", errorString);
+                }
+                return gearman_universal_set_error(universal, GEARMAN_LOST_CONNECTION, GEARMAN_AT,
+                                                   "lost connection to server (SSL peer closed without clean shutdown)");
               }
           }
         }
@@ -1189,9 +1196,13 @@ size_t gearman_connection_st::recv_socket(void *data, size_t data_size, gearman_
         default:
           {
             char errorString[SSL_ERROR_SIZE]= { 0 };
-            ERR_error_string_n(ssl_error, errorString, sizeof(errorString));
             close_socket();
-            return gearman_universal_set_error(universal, GEARMAN_LOST_CONNECTION, GEARMAN_AT, "SSL failure(%s)", errorString);
+            if (gearman_ssl_error_string(errorString, sizeof(errorString)))
+            {
+              return gearman_universal_set_error(universal, GEARMAN_LOST_CONNECTION, GEARMAN_AT, "SSL failure(%s)", errorString);
+            }
+            return gearman_universal_set_error(universal, GEARMAN_LOST_CONNECTION, GEARMAN_AT,
+                                               "lost connection to server (SSL peer closed without clean shutdown)");
           }
       }
     }

--- a/libgearman/ssl.h
+++ b/libgearman/ssl.h
@@ -51,6 +51,26 @@ enum {
 #  include <openssl/ssl.h>
 #  include <openssl/err.h>
 # endif
+
+/**
+ * Formats the next pending error off the OpenSSL/wolfSSL error queue into
+ * buf. SSL_get_error()'s return value (SSL_ERROR_SSL, SSL_ERROR_SYSCALL, ...)
+ * must never be passed directly to ERR_error_string_n() -- it is a small
+ * enum, not a packed OpenSSL error code, so doing so decodes garbage (e.g.
+ * SSL_ERROR_SYSCALL == 5 decodes as "DH lib"). Returns false if the queue is
+ * empty, which happens for SSL_ERROR_SYSCALL when the peer simply closed the
+ * connection without a clean SSL shutdown -- not a genuine SSL failure.
+ */
+static inline bool gearman_ssl_error_string(char *buf, size_t buf_size)
+{
+  unsigned long code= ERR_get_error();
+  if (code == 0)
+  {
+    return false;
+  }
+  ERR_error_string_n(code, buf, buf_size);
+  return true;
+}
 #else
 struct SSL_CTX {
 };


### PR DESCRIPTION
## Summary

`SSL_get_error()`'s return value (e.g. `SSL_ERROR_SYSCALL == 5`) was being passed directly to `ERR_error_string_n()`, which expects a packed error code from the OpenSSL error queue (`ERR_get_error()`). Decoding the raw enum value produces nonsense text — `SSL_ERROR_SYSCALL` decodes as `DH lib`, unrelated to Diffie-Hellman — which is exactly the confusing message reported in #28:

```
SSL failure(error:00000005:lib(0):func(0):DH lib) errno:0
```

This happens whenever a peer closes the connection without a clean SSL shutdown (`SSL_ERROR_SYSCALL` with `errno == 0`), which matches the report that it only fires "if client/worker closes socket connection."

- Added `gearman_ssl_error_string()` in `libgearman/ssl.h` to correctly pop the real error off the queue via `ERR_get_error()`.
- Replaced the broken pattern at every site it had been copy-pasted to:
  - `libgearman-server/io.cc` — server-side SSL read (`_connection_read`) and write (`_connection_flush`) paths
  - `libgearman-server/plugins/protocol/gear/protocol.cc` — `SSL_accept()` handshake failure path
  - `libgearman/connection.cc` — client-side connect/read/write paths
- When the error queue is empty (the common "peer closed without close_notify" case), log a plain "peer closed" message instead of feeding garbage into `ERR_error_string_n()`.

## Test plan

- [x] Rebuilt with `./configure --enable-ssl` (SSL is disabled by default in this checkout's config, so these code paths previously weren't even compiled) and `-Werror`; clean build, no warnings.
- [x] Manual smoke test: started `gearmand --ssl` with a self-signed cert, opened a raw TCP connection to the SSL port and closed it mid-handshake (reproducing the #28/#29 scenario). Log changed from the old garbage to a real decoded error:
  ```
  SSL_accept() failed: error:0A000126:SSL routines::unexpected eof while reading
  ```

Fixes #28.