### PR TITLE
Fix #29: null out dcon->server_con after freeing it on _con_add() failure

### DIFF
--- a/libgearman-server/gearmand_con.cc
+++ b/libgearman-server/gearmand_con.cc
@@ -86,6 +86,7 @@ static gearmand_error_t _con_add(gearmand_thread_st *thread,
     if (gearmand_failed(ret))
     {
       gearman_server_con_free(dcon->server_con);
+      dcon->server_con= NULL;
 
       dcon->close_socket();
 


### PR DESCRIPTION
## Summary

When `_con_add()` fails after `gearman_server_con_add()` already succeeded (e.g. the `SSL_accept()` handshake failure path hit by connection stampedes in #29), it frees `dcon->server_con` via `gearman_server_con_free()` but never clears the pointer on `dcon`:

```cpp
ret= dcon->add_fn(dcon->server_con);
if (gearmand_failed(ret))
{
  gearman_server_con_free(dcon->server_con);   // frees/recycles the object
  dcon->close_socket();
  return ret;                                  // dcon->server_con is still non-null
}
```

`gearmand_con_check_queue()` then sees `_con_add()` failed and calls `gearmand_con_free(dcon)`, which finds the stale non-null `dcon->server_con` and touches it a second time via `gearman_server_con_attempt_free()`:

- If the freed connection was recycled into the free-con pool (the common case), this just hits the `is_cleaned_up` guard and logs the noisy `con ... is already cleaned-up. returning` seen in #29's report.
- If the free-con pool was already at capacity, the first free actually `delete`d the object, so the second touch is a genuine use-after-free.
- In the normal threaded server, `gearman_server_con_attempt_free()` instead re-enqueues the (possibly already recycled for a brand new connection) object onto the proc queue — an object-reuse hazard, matching the code's own log warning: "please report any crashes that occur immediately after this."

`gearmand_con_free()` already special-cases `dcon->server_con == NULL` with the comment "server_con could be null if we failed to complete the initial connection" — the fix just makes `_con_add()` actually honor that contract on this failure path.

## Test plan

- [x] Rebuilt with `./configure --enable-ssl -Werror`; clean build.
- [x] Manual smoke test: started `gearmand --ssl`, opened a raw TCP connection and closed it mid-handshake (the same connection-stampede scenario from #29). Before the fix, the log showed:
  ```
  ERROR ... _con_add() has failed, please report any crashes...
  ERROR ... con 0x... is already cleaned-up. returning
  ```
  After the fix, the second ERROR line no longer appears.

Fixes #29.