### PR TITLE
Fix #59: replace redis KEYS with SCAN during queue replay

### DIFF
--- a/libgearman-server/plugins/queue/redis/queue.cc
+++ b/libgearman-server/plugins/queue/redis/queue.cc
@@ -388,68 +388,93 @@ static gearmand_error_t _hiredis_replay(gearman_server_st *server, void *context
 
   gearmand_info("hiredis replay start");
 
-  redisReply *reply= (redisReply*)redisCommand(queue->redis(), "KEYS %s*", queue->prefix.c_str());
-  if (reply == nullptr)
+  char fmt_str[100] = "";
+  int fmt_str_length= snprintf(fmt_str, sizeof(fmt_str), "%%%d[^-]-%%%d[^-]-%%%d[^*]",
+                               int(queue->prefix.size()),
+                               int(GEARMAN_FUNCTION_MAX_SIZE),
+                               int(GEARMAN_MAX_UNIQUE_SIZE));
+  if (fmt_str_length <= 0 or size_t(fmt_str_length) >= sizeof(fmt_str))
   {
-    return gearmand_log_gerror(
-      GEARMAN_DEFAULT_LOG_PARAM,
-      GEARMAND_QUEUE_ERROR,
-      "Failed to call KEYS during QUEUE replay: %s", queue->redis()->errstr);
+    assert(fmt_str_length != 1);
+    return gearmand_gerror(
+      "snprintf() failed to produce a valud fmt_str for redis key",
+      GEARMAND_QUEUE_ERROR);
   }
 
-  for (size_t x= 0; x < reply->elements; x++)
+  // KEYS blocks the whole redis server while it walks every key in the
+  // instance, which is painful if gearmand shares redis with other
+  // applications (#59). SCAN walks the keyspace incrementally via a
+  // cursor instead, so no single call blocks other clients. Note this
+  // still touches every key in the instance overall (just spread across
+  // many non-blocking calls) since matching still requires a per-key
+  // prefix comparison; see #59 for a proposed follow-up that tracks
+  // gearmand's own keys in a set to avoid that entirely.
+  std::string cursor= "0";
+  do
   {
-    char* prefix= (char*) malloc(queue->prefix.size() * sizeof(char));
-    char function_name[GEARMAN_FUNCTION_MAX_SIZE];
-    char unique[GEARMAN_MAX_UNIQUE_SIZE];
-
-    char fmt_str[100] = "";
-    int fmt_str_length= snprintf(fmt_str, sizeof(fmt_str), "%%%d[^-]-%%%d[^-]-%%%d[^*]",
-                                 int(queue->prefix.size()),
-                                 int(GEARMAN_FUNCTION_MAX_SIZE),
-                                 int(GEARMAN_MAX_UNIQUE_SIZE));
-    if (fmt_str_length <= 0 or size_t(fmt_str_length) >= sizeof(fmt_str))
-    {
-      free(prefix);
-      assert(fmt_str_length != 1);
-      return gearmand_gerror(
-        "snprintf() failed to produce a valud fmt_str for redis key",
-        GEARMAND_QUEUE_ERROR);
-    }
-    int ret= sscanf(reply->element[x]->str,
-                    fmt_str,
-                    prefix,
-                    function_name,
-                    unique);
-
-    free(prefix);
-    if (ret != 3)
-    {
-      continue;
-    }
-
-    gearmand::plugins::queue::redis_record_t record;
-    if(!queue->fetch(reply->element[x]->str, record))
+    redisReply *reply= (redisReply*)redisCommand(queue->redis(), "SCAN %s MATCH %s* COUNT 100",
+                                                  cursor.c_str(), queue->prefix.c_str());
+    if (reply == nullptr)
     {
       return gearmand_log_gerror(
         GEARMAN_DEFAULT_LOG_PARAM,
         GEARMAND_QUEUE_ERROR,
-        "Failed to fetch data for the key: %s", reply->element[x]->str);
+        "Failed to call SCAN during QUEUE replay: %s", queue->redis()->errstr);
     }
 
-    /* need to make a copy here ... gearman_server_job_free will free it later */
-    char *data = strdup(record.data.c_str());
-    size_t data_size = record.data.size();
-    gearman_job_priority_t priority = static_cast<gearman_job_priority_t>(record.priority);
+    if (reply->type != REDIS_REPLY_ARRAY or reply->elements != 2)
+    {
+      freeReplyObject(reply);
+      return gearmand_gerror(
+        "Unexpected reply shape from SCAN during QUEUE replay",
+        GEARMAND_QUEUE_ERROR);
+    }
 
-    (void)(add_fn)(server, add_context,
-                   unique, strlen(unique),
-                   function_name, strlen(function_name),
-                   data, data_size,
-                   priority, 0);
-  }
+    cursor.assign(reply->element[0]->str, reply->element[0]->len);
+    redisReply *keys= reply->element[1];
 
-  freeReplyObject(reply);
+    for (size_t x= 0; x < keys->elements; x++)
+    {
+      char* prefix= (char*) malloc((queue->prefix.size() +1) * sizeof(char));
+      char function_name[GEARMAN_FUNCTION_MAX_SIZE];
+      char unique[GEARMAN_MAX_UNIQUE_SIZE];
+
+      int ret= sscanf(keys->element[x]->str,
+                      fmt_str,
+                      prefix,
+                      function_name,
+                      unique);
+
+      free(prefix);
+      if (ret != 3)
+      {
+        continue;
+      }
+
+      gearmand::plugins::queue::redis_record_t record;
+      if(!queue->fetch(keys->element[x]->str, record))
+      {
+        freeReplyObject(reply);
+        return gearmand_log_gerror(
+          GEARMAN_DEFAULT_LOG_PARAM,
+          GEARMAND_QUEUE_ERROR,
+          "Failed to fetch data for the key: %s", keys->element[x]->str);
+      }
+
+      /* need to make a copy here ... gearman_server_job_free will free it later */
+      char *data = strdup(record.data.c_str());
+      size_t data_size = record.data.size();
+      gearman_job_priority_t priority = static_cast<gearman_job_priority_t>(record.priority);
+
+      (void)(add_fn)(server, add_context,
+                     unique, strlen(unique),
+                     function_name, strlen(function_name),
+                     data, data_size,
+                     priority, 0);
+    }
+
+    freeReplyObject(reply);
+  } while (cursor != "0");
 
   return GEARMAND_SUCCESS;
 }

--- a/libgearman-server/plugins/queue/redis/queue.cc
+++ b/libgearman-server/plugins/queue/redis/queue.cc
@@ -401,6 +401,19 @@ static gearmand_error_t _hiredis_replay(gearman_server_st *server, void *context
       GEARMAND_QUEUE_ERROR);
   }
 
+  // queue->prefix.size() is loop-invariant, so allocate the sscanf scratch
+  // buffer for it once here instead of once per key below -- it can't be a
+  // fixed-size stack buffer since --redis-prefix is an unbounded
+  // user-configurable string and sscanf's %<N>[^-] conversion writes up to
+  // queue->prefix.size() bytes into it.
+  char* prefix= (char*) malloc((queue->prefix.size() +1) * sizeof(char));
+  if (prefix == nullptr)
+  {
+    return gearmand_gerror(
+      "malloc() failed to allocate prefix scratch buffer for redis key",
+      GEARMAND_QUEUE_ERROR);
+  }
+
   // KEYS blocks the whole redis server while it walks every key in the
   // instance, which is painful if gearmand shares redis with other
   // applications (#59). SCAN walks the keyspace incrementally via a
@@ -416,15 +429,19 @@ static gearmand_error_t _hiredis_replay(gearman_server_st *server, void *context
                                                   cursor.c_str(), queue->prefix.c_str());
     if (reply == nullptr)
     {
+      free(prefix);
       return gearmand_log_gerror(
         GEARMAN_DEFAULT_LOG_PARAM,
         GEARMAND_QUEUE_ERROR,
         "Failed to call SCAN during QUEUE replay: %s", queue->redis()->errstr);
     }
 
-    if (reply->type != REDIS_REPLY_ARRAY or reply->elements != 2)
+    if (reply->type != REDIS_REPLY_ARRAY or reply->elements != 2 or
+        reply->element[0] == nullptr or reply->element[0]->type != REDIS_REPLY_STRING or
+        reply->element[1] == nullptr or reply->element[1]->type != REDIS_REPLY_ARRAY)
     {
       freeReplyObject(reply);
+      free(prefix);
       return gearmand_gerror(
         "Unexpected reply shape from SCAN during QUEUE replay",
         GEARMAND_QUEUE_ERROR);
@@ -435,7 +452,6 @@ static gearmand_error_t _hiredis_replay(gearman_server_st *server, void *context
 
     for (size_t x= 0; x < keys->elements; x++)
     {
-      char* prefix= (char*) malloc((queue->prefix.size() +1) * sizeof(char));
       char function_name[GEARMAN_FUNCTION_MAX_SIZE];
       char unique[GEARMAN_MAX_UNIQUE_SIZE];
 
@@ -445,7 +461,6 @@ static gearmand_error_t _hiredis_replay(gearman_server_st *server, void *context
                       function_name,
                       unique);
 
-      free(prefix);
       if (ret != 3)
       {
         continue;
@@ -455,6 +470,7 @@ static gearmand_error_t _hiredis_replay(gearman_server_st *server, void *context
       if(!queue->fetch(keys->element[x]->str, record))
       {
         freeReplyObject(reply);
+        free(prefix);
         return gearmand_log_gerror(
           GEARMAN_DEFAULT_LOG_PARAM,
           GEARMAND_QUEUE_ERROR,
@@ -476,6 +492,7 @@ static gearmand_error_t _hiredis_replay(gearman_server_st *server, void *context
     freeReplyObject(reply);
   } while (cursor != "0");
 
+  free(prefix);
   return GEARMAND_SUCCESS;
 }
 #pragma GCC diagnostic pop


### PR DESCRIPTION
## Summary

`_hiredis_replay()` used `KEYS %s*` to find persisted jobs on startup. `KEYS` is a blocking O(N) command over the whole redis keyspace, and the [redis docs explicitly warn against using it in production](https://redis.io/commands/keys) — if gearmand shares a redis instance with other applications, restarting gearmand stalls every other client on that instance for the duration of the scan.

This is the "quick fix" proposed in #59: switch to cursor-based `SCAN`, which walks the keyspace incrementally across many non-blocking calls instead of one blocking one.

Note total work done is still proportional to the whole redis keyspace (`SCAN` still has to pattern-match every key, just without blocking other clients while doing it), not just gearmand's own keys. The more complete fix — tracking gearmand's keys in a redis set (`SADD`/`SREM` alongside every `HMSET`/`DEL`) so replay is proportional to job count instead — needs a small refactor plus a migration path for existing redis-backed queues, so I've filed that separately: #488.

Also fixed while restructuring this function (found while rewriting it, both pre-existing):
- `reply` was leaked on the "Failed to fetch data" error path.
- the `malloc`'d `prefix` scratch buffer was undersized by one byte for the null terminator `sscanf`'s `%<N>[^-]` conversion writes.

## Test plan

- [x] Builds clean with `-Werror`.
- [x] Manual smoke test: started `gearmand` against a local redis with `--queue-type=redis`, submitted a background job with no worker running (so it persists to redis), restarted `gearmand`, and confirmed via debug log and `gearadmin --status` that the job was replayed via `SCAN` and successfully assigned to a worker afterward:
  ```
  DEBUG ... JOB H:ls03064:1 ...
  DEBUG ... Jobs available for reverse: 1
  DEBUG ... Sent JOB_ASSIGN_UNIQ
  ```

Fixes #59 (quick fix; complete fix tracked in #488).
