### PR TITLE
Fix #490: give the redis queue plugin real test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,6 +282,53 @@ jobs:
               echo "No test-suite.log file found."
            fi
 
+  build-with-redis:
+
+    name: 'ubuntu-24.04 gcc-15 +redis'
+    runs-on: ubuntu-24.04
+
+    env:
+      CC: gcc-15
+      CXX: g++-15
+      CCVERSION: '15'
+
+    steps:
+    - uses: actions/checkout@v7
+    - name: install dependencies
+      shell: bash
+      run: |
+           for i in 1 2 3 4 5; do sudo apt-add-repository -y ppa:ubuntu-toolchain-r/test && break || sleep 15; done
+           sudo apt-get update && sudo apt-get -o Acquire::Retries=3 install -y \
+             libboost-all-dev gperf libevent-dev uuid-dev sphinx-doc sphinx-common \
+             libhiredis-dev redis-server curl \
+             gcc-15 g++-15
+    - name: bootstrap
+      run: ./bootstrap.sh -a
+    - name: configure
+      run: |
+           CXXFLAGS="-Wp,-D_GLIBCXX_ASSERTIONS" \
+           ./configure --enable-ssl
+      shell: bash
+    - name: make
+      run: |
+           CXXFLAGS="-Wp,-D_GLIBCXX_ASSERTIONS" \
+           ${CC} --version && make
+      shell: bash
+    - name: make test
+      uses: nick-fields/retry@v4
+      with:
+        timeout_minutes: 10
+        max_attempts: 4
+        command: make test
+    - name: check test-suite.log
+      if: success() || failure()
+      run: |
+           if [ -f "./test-suite.log" ]; then
+              cat ./test-suite.log
+           else
+              echo "No test-suite.log file found."
+           fi
+
   build-with-postgresql:
 
     name: 'ubuntu-24.04 gcc-15 +postgresql'

--- a/configure.ac
+++ b/configure.ac
@@ -135,6 +135,7 @@ AC_PROG_INSTALL
 AC_PROG_LN_S
 AC_PROG_MAKE_SET
 AX_PROG_MEMCACHED
+AX_PROG_REDIS
 AX_PROG_SPHINX_BUILD(,[AC_MSG_WARN([sphinx-build version 1.0 or greater is required to build man pages])])
 AX_WITH_PROG([LCOV],[lcov])
 AX_WITH_PROG([LCOV_GENHTML],[genhtml])

--- a/libtest/has.cc
+++ b/libtest/has.cc
@@ -201,6 +201,32 @@ const char* memcached_binary()
   return NULL;
 }
 
+bool has_redis()
+{
+#if defined(HAVE_REDIS_SERVER_BINARY) && HAVE_REDIS_SERVER_BINARY
+  if (HAVE_REDIS_SERVER_BINARY)
+  {
+#if defined(REDIS_SERVER_BINARY)
+    if (access(REDIS_SERVER_BINARY, X_OK) == 0)
+    {
+      return true;
+    }
+#endif
+  }
+#endif
+
+  return false;
+}
+
+const char* redis_server_binary()
+{
+#if defined(REDIS_SERVER_BINARY)
+  return REDIS_SERVER_BINARY;
+#else
+  return NULL;
+#endif
+}
+
 const char *gearmand_binary() 
 {
 #if defined(GEARMAND_BINARY)

--- a/libtest/has.hpp
+++ b/libtest/has.hpp
@@ -69,8 +69,14 @@ LIBTEST_API
 const char* memcached_binary();
 
 LIBTEST_API
-const char *gearmand_binary(); 
+const char *gearmand_binary();
 
 LIBTEST_API
 const char *drizzled_binary();
+
+LIBTEST_API
+bool has_redis();
+
+LIBTEST_API
+const char* redis_server_binary();
 } // namespace libtest

--- a/libtest/include.am
+++ b/libtest/include.am
@@ -87,6 +87,7 @@ noinst_HEADERS+= libtest/memcached.h
 noinst_HEADERS+= libtest/memcached.hpp
 noinst_HEADERS+= libtest/poll_error.hpp
 noinst_HEADERS+= libtest/port.h
+noinst_HEADERS+= libtest/redis.h
 noinst_HEADERS+= libtest/result.hpp
 noinst_HEADERS+= libtest/result/base.hpp
 noinst_HEADERS+= libtest/result/fail.hpp
@@ -122,6 +123,7 @@ libtest_libtest_la_LIBADD=
 libtest_libtest_la_SOURCES=
 libtest_libtest_la_CXXFLAGS+= @LIBMEMCACHED_CFLAGS@
 libtest_libtest_la_LIBADD+= @LIBMEMCACHED_LIB@
+libtest_libtest_la_LIBADD+= @HIREDIS_LIB@
 if ENABLE_SSL
 if ENABLE_WOLFSSL
 libtest_libtest_la_LIBADD+= @WOLFSSL_LIB@
@@ -181,6 +183,7 @@ EXTRA_libtest_libtest_la_DEPENDENCIES+= libtest/wait
 
 # We are either building in tree, or with
 libtest_libtest_la_SOURCES+= libtest/memcached.cc
+libtest_libtest_la_SOURCES+= libtest/redis.cc
 
 libtest_libtest_la_LDFLAGS+= @LIBDRIZZLE_LDFLAGS@
 libtest_libtest_la_LIBADD+= @LIBDRIZZLE_LIB@

--- a/libtest/redis.cc
+++ b/libtest/redis.cc
@@ -1,0 +1,164 @@
+/*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
+ *
+ *  YATL (i.e. libtest) library
+ *
+ *  Copyright (C) 2026 Alexei Pastuchov
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are
+ *  met:
+ *
+ *      * Redistributions of source code must retain the above copyright
+ *  notice, this list of conditions and the following disclaimer.
+ *
+ *      * Redistributions in binary form must reproduce the above
+ *  copyright notice, this list of conditions and the following disclaimer
+ *  in the documentation and/or other materials provided with the
+ *  distribution.
+ *
+ *      * The names of its contributors may not be used to endorse or
+ *  promote products derived from this software without specific prior
+ *  written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "libtest/yatlcon.h"
+
+#include "libtest/common.h"
+
+#include <cstdio>
+#include <cstring>
+
+#include <libtest/server.h>
+#include <libtest/has.hpp>
+#include <libtest/redis.h>
+
+#if defined(HAVE_HIREDIS) && HAVE_HIREDIS
+#include <hiredis/hiredis.h>
+#endif
+
+#ifndef __INTEL_COMPILER
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif
+
+namespace libtest {
+
+class Redis : public libtest::Server
+{
+public:
+  Redis(const std::string& host_arg, const in_port_t port_arg) :
+    libtest::Server(host_arg, port_arg, redis_server_binary(), false)
+  {
+    set_pid_file();
+  }
+
+  bool ping()
+  {
+    if (out_of_ban_killed())
+    {
+      return false;
+    }
+
+#if defined(HAVE_HIREDIS) && HAVE_HIREDIS
+    redisContext *context= redisConnect(hostname().c_str(), int(port()));
+    if (context == nullptr)
+    {
+      return false;
+    }
+
+    bool success= (context->err == 0);
+    if (success)
+    {
+      redisReply *reply= (redisReply*)redisCommand(context, "PING");
+      success= (reply != nullptr and reply->type == REDIS_REPLY_STATUS);
+      if (reply)
+      {
+        freeReplyObject(reply);
+      }
+    }
+
+    redisFree(context);
+
+    return success;
+#else
+    return false;
+#endif
+  }
+
+  const char *name()
+  {
+    return "redis";
+  }
+
+  const char *executable()
+  {
+    return redis_server_binary();
+  }
+
+  bool is_libtool()
+  {
+    return false;
+  }
+
+  bool has_port_option() const
+  {
+    return true;
+  }
+
+  virtual void port_option(Application& app, in_port_t arg)
+  {
+    char buffer[30];
+    snprintf(buffer, sizeof(buffer), "%d", int(arg));
+    app.add_option("--port", buffer);
+  }
+
+  virtual void pid_file_option(Application& app, const std::string& arg)
+  {
+    if (arg.empty() == false)
+    {
+      app.add_option("--pidfile", arg);
+    }
+  }
+
+  bool is_valgrind() const
+  {
+    return false;
+  }
+
+  bool build();
+};
+
+bool Redis::build()
+{
+  // Keep the throwaway test instance in the foreground so libtest tracks
+  // its actual pid (it forks/execs redis-server itself and needs that pid
+  // to stay accurate; a self-daemonizing redis-server would otherwise
+  // leave libtest tracking the wrong process).
+  add_option("--daemonize", "no");
+
+  return true;
+}
+
+libtest::Server *build_redis(const std::string& hostname, const in_port_t try_port)
+{
+  if (has_redis())
+  {
+    return new Redis(hostname, try_port);
+  }
+
+  return NULL;
+}
+
+} // namespace libtest

--- a/libtest/redis.h
+++ b/libtest/redis.h
@@ -1,8 +1,8 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
  *
- *  Data Differential YATL (i.e. libtest)  library
+ *  YATL (i.e. libtest) library
  *
- *  Copyright (C) 2012 Data Differential, http://datadifferential.com/
+ *  Copyright (C) 2026 Alexei Pastuchov
  *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are
@@ -33,90 +33,11 @@
  *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  */
-/*
-  Common include file for libtest
-*/
 
 #pragma once
 
-#include <cassert>
-#include <cerrno>
-#include <cstdlib>
-#include <sstream>
-#include <string>
+namespace libtest {
 
-#ifdef HAVE_SYS_TYPES_H
-# include <sys/types.h>
-#endif
+libtest::Server *build_redis(const std::string& hostname, const in_port_t try_port);
 
-#ifdef HAVE_SYS_TIME_H
-# include <sys/time.h>
-#endif
-
-#ifdef HAVE_SYS_WAIT_H
-# include <sys/wait.h>
-#endif
-
-#ifdef HAVE_SYS_RESOURCE_H 
-# include <sys/resource.h> 
-#endif
- 
-#ifdef HAVE_FNMATCH_H
-# include <fnmatch.h>
-#endif
-
-#ifdef HAVE_ARPA_INET_H
-# include <arpa/inet.h>
-#endif
-
-#if defined(WIN32)
-# include "win32/wrappers.h"
-# define get_socket_errno() WSAGetLastError()
-#else
-# ifdef HAVE_UNISTD_H
-#  include <unistd.h>
-# endif
-# define INVALID_SOCKET -1
-# define SOCKET_ERROR -1
-# define closesocket(a) close(a)
-# define get_socket_errno() errno
-#endif
-
-#include <libtest/test.hpp>
-
-#include <libtest/is_pid.hpp>
-
-#include <libtest/gearmand.h>
-#include <libtest/blobslap_worker.h>
-#include <libtest/memcached.h>
-#include <libtest/drizzled.h>
-#include <libtest/redis.h>
-
-#include <libtest/libtool.hpp>
-#include <libtest/killpid.h>
-#include <libtest/signal.h>
-#include <libtest/dns.hpp>
-#include <libtest/formatter.hpp>
-
-struct FreeFromVector
-{
-  template <class T>
-    void operator() ( T* ptr) const
-    {
-      if (ptr)
-      {
-        free(ptr);
-        ptr= NULL;
-      }
-    }
-};
-
-struct DeleteFromVector
-{
-  template <class T>
-    void operator() ( T* ptr) const
-    {
-      delete ptr;
-      ptr= NULL;
-    }
-};
+}

--- a/libtest/server_container.cc
+++ b/libtest/server_container.cc
@@ -248,6 +248,13 @@ libtest::Server* server_startup_st::create(const std::string& server_type, in_po
       server= build_memcached("localhost", try_port);
     }
   }
+  else if (server_type.compare("redis") == 0)
+  {
+    if (has_redis())
+    {
+      server= build_redis("localhost", try_port);
+    }
+  }
 
   return server;
 }

--- a/m4/ax_redis.m4
+++ b/m4/ax_redis.m4
@@ -1,0 +1,59 @@
+# vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
+# ===========================================================================
+#      https://github.com/BrianAker/ddm4/
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_PROG_REDIS
+#
+# DESCRIPTION
+#
+#   Check for redis-server, used to spawn a throwaway instance for the
+#   redis queue plugin's test suite.
+#
+# LICENSE
+#
+#  Copyright (C) 2026 Alexei Pastuchov
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above copyright
+#  notice, this list of conditions and the following disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#  copyright notice, this list of conditions and the following disclaimer
+#  in the documentation and/or other materials provided with the
+#  distribution.
+#
+#      * The names of its contributors may not be used to endorse or
+#  promote products derived from this software without specific prior
+#  written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#serial 1
+
+AC_DEFUN([AX_PROG_REDIS],
+         [AX_WITH_PROG([REDIS_SERVER_BINARY],[redis-server],[unknown])
+         AS_IF([test x"$REDIS_SERVER_BINARY" != xunknown -a -x "$REDIS_SERVER_BINARY"],
+               [AC_DEFINE([HAVE_REDIS_SERVER_BINARY], [1], [If redis-server binary is available])
+               AC_DEFINE_UNQUOTED([REDIS_SERVER_BINARY],"$REDIS_SERVER_BINARY",[Name of the redis-server binary used in make test])
+               ],
+               [AC_DEFINE([HAVE_REDIS_SERVER_BINARY], [0], [If redis-server binary is available])
+               REDIS_SERVER_BINARY=
+               ])
+         ])

--- a/tests/redis.cc
+++ b/tests/redis.cc
@@ -57,9 +57,11 @@ using namespace libtest;
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif
 
+static in_port_t redis_port= 0;
+
 static test_return_t gearmand_basic_option_test(void *)
 {
-  const char *args[]= { "--check-args", 
+  const char *args[]= { "--check-args",
     "--redis-server=localhost",
     "--redis-port=6379",
     0 };
@@ -70,26 +72,53 @@ static test_return_t gearmand_basic_option_test(void *)
 
 static test_return_t collection_init(void *object)
 {
-  SKIP_IF(true);
   Context *test= (Context *)object;
   assert(test);
 
-  const char *argv[]= { "--queue-type=redis", 0 };
+  redis_port= libtest::get_free_port();
+  ASSERT_TRUE(server_startup(test->_servers, "redis", redis_port, NULL));
 
-  test->initialize(argv);
+  char redis_port_string[1024];
+  int length= snprintf(redis_port_string,
+                       sizeof(redis_port_string),
+                       "--redis-port=%d",
+                       int(redis_port));
+  ASSERT_TRUE(size_t(length) < sizeof(redis_port_string));
+
+  const char *argv[]= {
+    "--queue-type=redis",
+    "--redis-server=localhost",
+    redis_port_string,
+    0 };
+
+  ASSERT_TRUE(test->initialize(argv));
 
   return TEST_SUCCESS;
 }
 
 static test_return_t collection_init_with_prefix(void *object)
 {
-  SKIP_IF(true);
   Context *test= (Context *)object;
   assert(test);
 
-  const char *argv[]= { "--queue-type=redis", "--redis-prefix=_prefix_", 0 };
+  redis_port= libtest::get_free_port();
+  ASSERT_TRUE(server_startup(test->_servers, "redis", redis_port, NULL));
 
-  test->initialize(argv);
+  char redis_port_string[1024];
+  int length= snprintf(redis_port_string,
+                       sizeof(redis_port_string),
+                       "--redis-port=%d",
+                       int(redis_port));
+  ASSERT_TRUE(size_t(length) < sizeof(redis_port_string));
+
+  const char *argv[]= {
+    "--queue-type=redis",
+    "--redis-server=localhost",
+    redis_port_string,
+    "--redis-prefix=_prefix_",
+    0 };
+
+  ASSERT_TRUE(test->initialize(argv));
 
   return TEST_SUCCESS;
 }
@@ -118,6 +147,7 @@ static bool test_for_HAVE_HIREDIS()
 static void *world_create(server_startup_st& servers, test_return_t&)
 {
   SKIP_IF(test_for_HAVE_HIREDIS() == false);
+  SKIP_IF(has_redis() == false);
   return new Context(servers);
 }
 


### PR DESCRIPTION
## Summary

`tests/redis.cc`'s `collection_init` and `collection_init_with_prefix` — the two collections covering add/worker/clean/echo and the regression test — were gated behind an unconditional `SKIP_IF(true)` ever since the file was first added in 2013 (`162a931c`) and never revisited. Unlike every other queue plugin, redis had neither a spawnable test server (like memcached's `libtest/memcached.cc`) nor an availability probe (like mysql/postgres/drizzle's `has_mysqld()`/`has_postgres_support()`/`has_drizzled()`), so there was no way to run these tests even if someone removed the skip.

This brings redis to parity with memcached:

- **`m4/ax_redis.m4` + `configure.ac`**: probe for the `redis-server` binary at configure time (`AX_PROG_REDIS`), defining `REDIS_SERVER_BINARY` / `HAVE_REDIS_SERVER_BINARY`, mirroring `AX_PROG_MEMCACHED`.
- **`libtest/has.{cc,hpp}`**: add `has_redis()` / `redis_server_binary()`, mirroring `has_memcached()` / `memcached_binary()`.
- **`libtest/redis.{h,cc}`** (new): a `Redis : public libtest::Server` class that spawns a real `redis-server` subprocess for the test's duration (foreground, `--daemonize no`; `--port` and `--pidfile` need space-separated argv, not `--flag=value` — redis-server misparses the latter as part of the config value), with `ping()` implemented as a real hiredis `PING` instead of a raw string probe.
- **`libtest/server_container.cc`**: wire up `server_type == "redis"` the same way `"memcached"` is, gated on `has_redis()`.
- **`tests/redis.cc`**: remove both `SKIP_IF(true)`; `collection_init` and `collection_init_with_prefix` now spawn a real `redis-server` via `server_startup()` and point gearmand at it, exactly like `memcached_test.cc`'s `collection_init()`. `world_create()` now also `SKIP_IF`s on `has_redis()` (not just `HAVE_HIREDIS`), so environments without a `redis-server` binary still skip cleanly (exit 77) instead of hitting an assertion failure inside `collection_init()`.

## Test plan

- [x] With `redis-server` available: all 14 redis tests pass (previously only 1 ever ran) — echo/clean/add/worker, both with and without a key prefix, plus the `lp:734663` regression test. Stable across repeated runs, no leaked `redis-server`/`gearmand` processes afterward.
- [x] Without `redis-server` on `PATH`: the suite now skips cleanly (exit 77) instead of failing an assertion.
- [x] Full project rebuild is clean with `-Werror`.
- [x] No regressions in `t/protocol`, `t/cli`, `t/gearmand`, `t/vector`, `t/result`.

Fixes #490.