### PR TITLE
Update Dependabot configuration to ignore minor and patchlevel version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,13 @@ updates:
     labels:
         - "dependencies"
         - "github-actions"
+    # Only open PRs for major version bumps of Actions.
+    # Minor/patch updates are unnecessary when using floating major tags (e.g. @v4).
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     # Group updates together (newer Dependabot feature)
     groups:
       actions:


### PR DESCRIPTION
Another GitHub repo I work on started to get Dependabot PRs for minor and patchlevel version number bumps to GitHub Actions workflows. This PR updates the Dependabot configuration to ignore such minor and patch version number bumps in GitHub Actions workflows as they are unnecessary.