### PR TITLE
Fix remaining unlocked pre-check races in connection lifecycle code (#460)

### DIFF
--- a/libgearman-server/connection.cc
+++ b/libgearman-server/connection.cc
@@ -527,11 +527,29 @@ void gearman_server_con_io_remove(gearman_server_con_st *con)
 gearman_server_con_st *
 gearman_server_con_io_next(gearman_server_thread_st *thread)
 {
-  gearman_server_con_st *con= thread->io_list;
+  gearman_server_con_st *con= NULL;
 
-  if (con)
+  /* thread->io_list is mutated under thread->lock by other threads (e.g.
+     gearman_server_con_io_add()), so it must not be read before taking
+     the lock below. */
+  int lock_error;
+  if ((lock_error= pthread_mutex_lock(&thread->lock)) == 0)
   {
-    gearman_server_con_io_remove(con);
+    con= thread->io_list;
+    if (con)
+    {
+      GEARMAND_LIST_DEL(thread->io, con, io_);
+      con->io_list= false;
+    }
+
+    if ((lock_error= pthread_mutex_unlock(&thread->lock)))
+    {
+      gearmand_log_fatal_perror(GEARMAN_DEFAULT_LOG_PARAM, lock_error, "pthread_mutex_unlock");
+    }
+  }
+  else
+  {
+    gearmand_log_fatal_perror(GEARMAN_DEFAULT_LOG_PARAM, lock_error, "pthread_mutex_lock");
   }
 
   return con;
@@ -609,13 +627,11 @@ void gearman_server_con_proc_remove(gearman_server_con_st *con)
 gearman_server_con_st *
 gearman_server_con_proc_next(gearman_server_thread_st *thread)
 {
-  if (thread->proc_list == NULL)
-  {
-    return NULL;
-  }
-
   gearman_server_con_st *con= NULL;
 
+  /* thread->proc_list is mutated under thread->lock by other threads (e.g.
+     gearman_server_con_proc_add()), so it must not be read before taking
+     the lock below. */
   int pthread_error;
   if ((pthread_error= pthread_mutex_lock(&thread->lock)) == 0)
   {

--- a/libgearman-server/packet.cc
+++ b/libgearman-server/packet.cc
@@ -252,23 +252,27 @@ void gearman_server_proc_packet_add(gearman_server_con_st *con,
 gearman_server_packet_st *
 gearman_server_proc_packet_remove(gearman_server_con_st *con)
 {
-  gearman_server_packet_st *server_packet= con->proc_packet_list;
+  gearman_server_packet_st *server_packet= NULL;
 
-  if (server_packet)
+  /* con->proc_packet_list is mutated under con->thread->lock by other
+     threads (e.g. gearman_server_proc_packet_add()), so it must not be
+     read before taking the lock below. */
+  int error;
+  if ((error= pthread_mutex_lock(&con->thread->lock)) == 0)
   {
-    int error;
-    if ((error= pthread_mutex_lock(&con->thread->lock)) == 0)
+    server_packet= con->proc_packet_list;
+    if (server_packet)
     {
       GEARMAND_FIFO__DEL(con->proc_packet, server_packet);
-      if ((error= pthread_mutex_unlock(&con->thread->lock)) != 0)
-      {
-        gearmand_log_fatal_perror(GEARMAN_DEFAULT_LOG_PARAM, error, "pthread_mutex_unlock");
-      }
     }
-    else
+    if ((error= pthread_mutex_unlock(&con->thread->lock)) != 0)
     {
-      gearmand_log_fatal_perror(GEARMAN_DEFAULT_LOG_PARAM, error, "pthread_mutex_lock");
+      gearmand_log_fatal_perror(GEARMAN_DEFAULT_LOG_PARAM, error, "pthread_mutex_unlock");
     }
+  }
+  else
+  {
+    gearmand_log_fatal_perror(GEARMAN_DEFAULT_LOG_PARAM, error, "pthread_mutex_lock");
   }
 
   return server_packet;


### PR DESCRIPTION
## Summary

Follow-up to #482. That PR fixed the unlocked-pre-check race in `gearman_server_con_to_be_freed_next()` (reading `thread->to_be_freed_list` before acquiring the same lock the writer always uses), but the identical pattern was still present in three sibling functions called out in #460's "other race sites" list:

- `gearman_server_con_io_next()` (`libgearman-server/connection.cc`) — read `thread->io_list` directly, then called the locked remove helper separately, leaving a window where the head pointer is read outside any lock.
- `gearman_server_con_proc_next()` (`libgearman-server/connection.cc`) — had an unlocked `if (thread->proc_list == NULL) return NULL;` pre-check ahead of the lock.
- `gearman_server_proc_packet_remove()` (`libgearman-server/packet.cc`) — read `con->proc_packet_list` unlocked before locking to delete from the FIFO.

All three now read the list head only after acquiring `thread->lock` / `con->thread->lock`, matching the pattern #482 already established for `to_be_freed_next()`.

This does **not** touch the other items still open in #460 (the intentionally-racy `dcon_add_count`/`io_count`/`proc_count` wakeup fast-paths in `gearmand_con.cc`, or the deeper architectural items around `gearman_io_send`'s send buffer and `Geartext::pack`) — those need a separate design discussion, not a lock fix.

## Test plan

- [x] Normal build compiles cleanly with `-Werror`.
- [x] Built and linked `gearmand`/`gearman` binaries successfully.
- [x] Ran `gearmand --threads=4`, hammered with 16 concurrent `gearman` clients submitting 300 background jobs each (4800 total, no worker) — server stayed alive throughout, matching #482's test methodology.

Refs #460