### PR TITLE
Make dcon_add_count and con->ret atomic (#460)

### DIFF
--- a/libgearman-server/struct/gearmand_thread.h
+++ b/libgearman-server/struct/gearmand_thread.h
@@ -37,6 +37,8 @@
 
 #pragma once
 
+#include <atomic>
+
 struct gearmand_st;
 
 struct gearmand_thread_st
@@ -45,7 +47,11 @@ struct gearmand_thread_st
   bool is_wakeup_event;
   uint32_t count;
   uint32_t dcon_count;
-  uint32_t dcon_add_count;
+  // Written unlocked by the main thread (gearmand_con_create()'s "no need
+  // to lock if empty" fast path) and read unlocked by this thread's own
+  // gearmand_con_check_queue(), so it must be atomic rather than plain
+  // uint32_t.
+  std::atomic<uint32_t> dcon_add_count;
   uint32_t free_dcon_count;
   int wakeup_fd[2];
   gearmand_st& _gearmand;

--- a/libgearman-server/struct/io.h
+++ b/libgearman-server/struct/io.h
@@ -156,7 +156,11 @@ struct gearman_server_con_st
   std::atomic<bool> is_dead{false};
   bool is_noop_sent{};
   bool is_cleaned_up{};
-  gearmand_error_t ret{};
+  // Set by the proc thread (gearmand_con.cc's _proc()) and polled by the
+  // IO thread (thread.cc's gearman_server_thread_run()) with no other
+  // synchronization, so this must be atomic rather than plain
+  // gearmand_error_t.
+  std::atomic<gearmand_error_t> ret{GEARMAND_SUCCESS};
   std::atomic<bool> io_list{false};
   std::atomic<bool> proc_list{false};
   std::atomic<bool> proc_removed{false};


### PR DESCRIPTION
## Summary

Another follow-up to #460 (independent of #493 — different fields, no overlap).

- `gearmand_thread_st::dcon_add_count` is incremented unlocked by the main thread in `gearmand_con_create()`'s "no need to lock if empty" fast path, and polled unlocked by the owning IO thread in `gearmand_con_check_queue()`. Converted to `std::atomic<uint32_t>`.
- `gearman_server_con_st::ret` is written by the proc thread in `_proc()` (`gearmand_con.cc`) and read by the IO thread in `gearman_server_thread_run()` (`thread.cc`), with no lock covering it at all. Converted to `std::atomic<gearmand_error_t>`. This one was explicitly called out as a known gap in #482's own description ("a `con->ret` race not named in the issue, left out of scope") — this closes it out using the same pattern already applied to `is_dead`/`io_list`/`proc_list`/`proc_removed`/`to_be_freed_list`.

I also checked `io_count`/`proc_count` (`gearman_server_thread_st`) against the issue's "other race sites" list before touching them: every current read of both is already inside the `con->thread->lock` critical section (see the comment at `connection.cc:478`), so there's nothing to fix there — left as plain `uint32_t`.

Not in scope here: the adjacent unlocked `dcon_add_list` pointer read in `gearmand_con_check_queue()`'s `while` loop condition, which is the same lock-ordering pattern #493 fixes elsewhere — better suited to a #493-style PR than an atomics-only one.

## Test plan

- [x] Normal build compiles cleanly with `-Werror`.
- [x] Built and linked `gearmand`/`gearman` binaries successfully.
- [x] Ran `gearmand --threads=4`, hammered with 16 concurrent `gearman` clients submitting 300 background jobs each (4800 total, no worker) — server stayed alive throughout, matching #482/#493's test methodology.

Refs #460