### PR TITLE
Fix unlocked dcon_add_list pre-check in gearmand_con_check_queue() (#460)

### DIFF
--- a/libgearman-server/gearmand_con.cc
+++ b/libgearman-server/gearmand_con.cc
@@ -776,34 +776,47 @@ void gearmand_con_check_queue(gearmand_thread_st *thread)
   }
 
   /* We want to add new connections inside the lock because other threads may
-     walk the thread's dcon_list while holding the lock. */
-  while (thread->dcon_add_list != NULL)
+     walk the thread's dcon_list while holding the lock. thread->dcon_add_list
+     is mutated under thread->lock by other threads (e.g. gearmand_con_create()),
+     so it must not be read before taking the lock below either. */
+  while (1)
   {
+    gearmand_con_st *dcon= NULL;
+
     int error;
     if ((error= pthread_mutex_lock(&(thread->lock))) == 0)
     {
-      gearmand_con_st *dcon= thread->dcon_add_list;
-      GEARMAND_LIST__DEL(thread->dcon_add, dcon);
+      dcon= thread->dcon_add_list;
+      if (dcon)
+      {
+        GEARMAND_LIST__DEL(thread->dcon_add, dcon);
+      }
 
       if ((error= pthread_mutex_unlock(&(thread->lock))))
       {
         gearmand_log_fatal_perror(GEARMAN_DEFAULT_LOG_PARAM, error, "pthread_mutex_unlock");
         gearmand_wakeup(Gearmand(), GEARMAND_WAKEUP_SHUTDOWN);
       }
-
-      gearmand_error_t rc;
-      if ((rc= _con_add(thread, dcon)) != GEARMAND_SUCCESS)
-      {
-        gearmand_log_gerror(GEARMAN_DEFAULT_LOG_PARAM, rc, "%s:%s _con_add() has failed, please report any crashes that occur immediately after this.",
-                            dcon->host,
-                            dcon->port);
-        gearmand_con_free(dcon);
-      }
     }
     else
     {
       gearmand_log_fatal_perror(GEARMAN_DEFAULT_LOG_PARAM, error, "pthread_mutex_lock");
       gearmand_wakeup(Gearmand(), GEARMAND_WAKEUP_SHUTDOWN);
+      return;
+    }
+
+    if (dcon == NULL)
+    {
+      break;
+    }
+
+    gearmand_error_t rc;
+    if ((rc= _con_add(thread, dcon)) != GEARMAND_SUCCESS)
+    {
+      gearmand_log_gerror(GEARMAN_DEFAULT_LOG_PARAM, rc, "%s:%s _con_add() has failed, please report any crashes that occur immediately after this.",
+                          dcon->host,
+                          dcon->port);
+      gearmand_con_free(dcon);
     }
   }
 }


### PR DESCRIPTION
## Summary

Another follow-up to #460, independent of #493/#494 (different file/lines, no overlap).

`gearmand_con_check_queue()`'s `while (thread->dcon_add_list != NULL)` loop condition read that linked-list head pointer before taking `thread->lock`, racing against the writer (`gearmand_con_create()`), which always mutates `dcon_add_list` under that same lock (both in its locked slow path and, more subtly, in its unlocked-but-single-writer fast path). This is the exact same pattern already fixed for `gearman_server_con_io_next()`/`gearman_server_con_proc_next()`/`gearman_server_proc_packet_remove()` in #493 — fold the read into the locked critical section instead of checking the pointer beforehand.

The `thread->dcon_add_count == 0` dirty-check a few lines above is untouched — that one's an intentional fast-path documented in its own comment ("wakeup is always sent after add completes"), not the same bug.

## Test plan

- [x] Normal build compiles cleanly with `-Werror`.
- [x] Built and linked `gearmand`/`gearman` binaries successfully.
- [x] Ran `gearmand --threads=4`, hammered with 32 concurrent `gearman` clients each opening 200 short-lived connections to submit background jobs (6400 total, no worker) — heavier connection churn than #482's original repro, since this fix is specifically about new-connection queuing. Server stayed alive throughout.

Refs #460