### PR TITLE
Fix unlocked Server->proc_wakeup/proc_shutdown read in proc_add() (#460)

### DIFF
--- a/libgearman-server/connection.cc
+++ b/libgearman-server/connection.cc
@@ -554,27 +554,28 @@ void gearman_server_con_proc_add(gearman_server_con_st *con)
       gearmand_log_fatal_perror(GEARMAN_DEFAULT_LOG_PARAM, pthread_error, "pthread_mutex_unlock");
     }
 
-    if (! (Server->proc_shutdown) && !(Server->proc_wakeup))
+    /* Server->proc_shutdown/proc_wakeup are plain bool, mutated under
+       Server->proc_lock by other threads calling this same function, so
+       they must not be read before taking that lock. */
+    if ((pthread_error= pthread_mutex_lock(&(Server->proc_lock))) == 0)
     {
-      if ((pthread_error= pthread_mutex_lock(&(Server->proc_lock))) == 0)
+      if (! (Server->proc_shutdown) && !(Server->proc_wakeup))
       {
         Server->proc_wakeup= true;
-        if ((pthread_error= pthread_cond_signal(&(Server->proc_cond))) == 0)
-        {
-          if ((pthread_error= pthread_mutex_unlock(&(Server->proc_lock))))
-          {
-            gearmand_log_fatal_perror(GEARMAN_DEFAULT_LOG_PARAM, pthread_error, "pthread_mutex_unlock");
-          }
-        }
-        else
+        if ((pthread_error= pthread_cond_signal(&(Server->proc_cond))))
         {
           gearmand_log_fatal_perror(GEARMAN_DEFAULT_LOG_PARAM, pthread_error, "pthread_cond_signal");
         }
       }
-      else
+
+      if ((pthread_error= pthread_mutex_unlock(&(Server->proc_lock))))
       {
-        gearmand_log_fatal_perror(GEARMAN_DEFAULT_LOG_PARAM, pthread_error, "pthread_mutex_lock");
+        gearmand_log_fatal_perror(GEARMAN_DEFAULT_LOG_PARAM, pthread_error, "pthread_mutex_unlock");
       }
+    }
+    else
+    {
+      gearmand_log_fatal_perror(GEARMAN_DEFAULT_LOG_PARAM, pthread_error, "pthread_mutex_lock");
     }
   }
   else


### PR DESCRIPTION
## Summary

Another follow-up to #460, found by re-running TSAN against master + #493 + #494 + #495 combined (built with `-fsanitize=thread`, stress-tested with 16x300 + 32x200 concurrent `gearman` clients submitting background jobs, no worker — 11,200 jobs total).

`gearman_server_con_proc_add()` checked `!(Server->proc_shutdown) && !(Server->proc_wakeup)` *before* deciding whether to lock `Server->proc_lock` and signal the proc thread. Both fields are plain `bool` on the `Server` singleton, mutated under that same lock by concurrent calls to this function from other IO threads (e.g. one thread processing an incoming packet via `gearman_server_proc_packet_add()`, another freeing a dead connection via `gearman_server_con_attempt_free()`). Moved the check inside the lock — same shape as every other fix in this series.

I initially misattributed this to `con->proc_list` (already `std::atomic<bool>` from #482, so not actually racy) based on a first pass over the TSAN output — the heap-block size in the report pointed at the `Server` singleton, not a per-connection object, and the real target turned out to be `proc_wakeup`/`proc_shutdown`. This single unlocked check accounted for 6 of the 12 reports in that combined run (one was misattributed by the sanitizer itself to `gearmand_con.cc:493`, due to `-O1` inlining `gearman_server_con_proc_next()` into `_proc()` — same underlying field).

## Test plan

- [x] Normal build compiles cleanly with `-Werror`.
- [x] Re-ran the TSAN build/repro (`--threads=4`, same 16x300 + 32x200 workload) against this fix alone, on top of master without #493/#494/#495: zero reports on `Server->proc_wakeup`/`proc_shutdown` remain. Everything else observed in that run is either an already-fixed-elsewhere bug reappearing (since this branch doesn't include #493/#494/#495) or the still-open `gearmand_con_create()` fast-path cluster (tracked separately on #460).

Refs #460