### PR TITLE
Fix #159: store function/unique as redis hash fields, not just in the key

### DIFF
--- a/libgearman-server/plugins/queue/redis/queue.cc
+++ b/libgearman-server/plugins/queue/redis/queue.cc
@@ -157,13 +157,17 @@ redisContext* gearmand::plugins::queue::Hiredis::redis()
 }
 
 /*
- * gearmand::plugins::queue::Hiredis::hmset(vchar_t key, const void *data, size_t data_size, uint32_t priority)
+ * gearmand::plugins::queue::Hiredis::hmset(vchar_t key, const void *data, size_t data_size, uint32_t priority,
+ *                                          const char *function_name, size_t function_name_size,
+ *                                          const char *unique, size_t unique_size)
  *
  * returns true if hiredis HMSET succeeded
  */
-bool gearmand::plugins::queue::Hiredis::hmset(vchar_t key, const void *data, size_t data_size, uint32_t priority) {
+bool gearmand::plugins::queue::Hiredis::hmset(vchar_t key, const void *data, size_t data_size, uint32_t priority,
+                                              const char *function_name, size_t function_name_size,
+                                              const char *unique, size_t unique_size) {
   redisContext* context = this->redis();
-  const size_t argc = 6;
+  const size_t argc = 10;
   std::string _priority = std::to_string((uint32_t)priority);
 
   const size_t argvlen[argc] = {
@@ -172,7 +176,11 @@ bool gearmand::plugins::queue::Hiredis::hmset(vchar_t key, const void *data, siz
     (size_t)4,
     (size_t)data_size,
     (size_t)8,
-    _priority.size()
+    _priority.size(),
+    (size_t)8,
+    function_name_size,
+    (size_t)6,
+    unique_size
   };
 
   std::vector<const char*> argv {"HMSET"};
@@ -181,6 +189,10 @@ bool gearmand::plugins::queue::Hiredis::hmset(vchar_t key, const void *data, siz
   argv.push_back( static_cast<const char*>(data) );
   argv.push_back( "priority" );
   argv.push_back( _priority.c_str() );
+  argv.push_back( "function" );
+  argv.push_back( function_name );
+  argv.push_back( "unique" );
+  argv.push_back( unique );
 
   redisReply *reply = (redisReply *)redisCommandArgv(context, static_cast<int>(argv.size()), &(argv[0]), &(argvlen[0]) );
   if (reply == nullptr)
@@ -230,19 +242,37 @@ bool gearmand::plugins::queue::Hiredis::fetch(char *key, gearmand::plugins::queu
     req.data = s;
     req.priority = GEARMAN_JOB_PRIORITY_NORMAL;
   } else {
-    // 2 x (key + value)
-    assert(reply->elements == 4);
-    auto fk = reply->element[0]->str;
-    if(strcmp(fk, "data") == 0) {
-      std::string s{reply->element[1]->str};
-      req.data = s;
-      req.priority = (uint32_t)std::stoi(reply->element[3]->str);
-    } else if (strcmp(fk, "priority") == 0) {
-      std::string s{reply->element[3]->str};
-      req.data = s;
-      req.priority = (uint32_t)std::stoi(reply->element[1]->str);
-    } else {
-      gearmand_log_error(GEARMAN_DEFAULT_LOG_PARAM, "unexpected key %s", fk);
+    // HGETALL replies with a flat [field, value, field, value, ...] array.
+    // Older gearmand versions only ever wrote "data"/"priority" (#159 added
+    // "function"/"unique" so replay doesn't have to parse them back out of
+    // the key), so this has to tolerate either shape rather than assuming a
+    // fixed field count.
+    assert(reply->elements % 2 == 0);
+    bool have_data= false;
+    bool have_priority= false;
+    for (size_t i= 0; i + 1 < reply->elements; i+= 2)
+    {
+      const char *field= reply->element[i]->str;
+      const char *value= reply->element[i + 1]->str;
+
+      if (strcmp(field, "data") == 0) {
+        req.data= std::string{value};
+        have_data= true;
+      } else if (strcmp(field, "priority") == 0) {
+        req.priority= (uint32_t)std::stoi(value);
+        have_priority= true;
+      } else if (strcmp(field, "function") == 0) {
+        req.function_name= std::string{value};
+      } else if (strcmp(field, "unique") == 0) {
+        req.unique= std::string{value};
+      } else {
+        gearmand_log_error(GEARMAN_DEFAULT_LOG_PARAM, "unexpected key %s", field);
+        return false;
+      }
+    }
+
+    if (have_data == false or have_priority == false) {
+      gearmand_log_error(GEARMAN_DEFAULT_LOG_PARAM, "missing data/priority field(s) for key: %s", key);
       return false;
     }
   }
@@ -408,7 +438,8 @@ static gearmand_error_t _hiredis_add(gearman_server_st *, void *context,
   gearmand_log_debug(
     GEARMAN_DEFAULT_LOG_PARAM,
     "hires key: %u", (uint32_t)key.size());
-  if (queue->hmset(key, data, data_size, (uint32_t)priority))
+  if (queue->hmset(key, data, data_size, (uint32_t)priority,
+                  function_name, function_name_size, unique, unique_size))
     return GEARMAND_SUCCESS;
 
   return gearmand_log_gerror(
@@ -525,20 +556,6 @@ static gearmand_error_t _hiredis_replay(gearman_server_st *server, void *context
 
     for (size_t x= 0; x < keys->elements; x++)
     {
-      char function_name[GEARMAN_FUNCTION_MAX_SIZE];
-      char unique[GEARMAN_MAX_UNIQUE_SIZE];
-
-      int ret= sscanf(keys->element[x]->str,
-                      fmt_str,
-                      prefix,
-                      function_name,
-                      unique);
-
-      if (ret != 3)
-      {
-        continue;
-      }
-
       gearmand::plugins::queue::redis_record_t record;
       if(!queue->fetch(keys->element[x]->str, record))
       {
@@ -548,6 +565,36 @@ static gearmand_error_t _hiredis_replay(gearman_server_st *server, void *context
           GEARMAN_DEFAULT_LOG_PARAM,
           GEARMAND_QUEUE_ERROR,
           "Failed to fetch data for the key: %s", keys->element[x]->str);
+      }
+
+      // Prefer the "function"/"unique" hash fields (#159) over parsing them
+      // out of the key: the key uses '-' as a delimiter, which breaks for
+      // function names or unique IDs that contain a hyphen. Fall back to
+      // parsing the key only for entries written before that fix.
+      char parsed_function_name[GEARMAN_FUNCTION_MAX_SIZE];
+      char parsed_unique[GEARMAN_MAX_UNIQUE_SIZE];
+      const char *function_name;
+      const char *unique;
+
+      if (record.function_name.empty() == false and record.unique.empty() == false)
+      {
+        function_name= record.function_name.c_str();
+        unique= record.unique.c_str();
+      }
+      else
+      {
+        int ret= sscanf(keys->element[x]->str,
+                        fmt_str,
+                        prefix,
+                        parsed_function_name,
+                        parsed_unique);
+        if (ret != 3)
+        {
+          continue;
+        }
+
+        function_name= parsed_function_name;
+        unique= parsed_unique;
       }
 
       /* need to make a copy here ... gearman_server_job_free will free it later */

--- a/libgearman-server/plugins/queue/redis/queue.cc
+++ b/libgearman-server/plugins/queue/redis/queue.cc
@@ -169,10 +169,13 @@ bool gearmand::plugins::queue::Hiredis::hmset(vchar_t key, const void *data, siz
                                               const char *function_name, size_t function_name_size,
                                               const char *unique, size_t unique_size) {
   redisContext* context = this->redis();
-  const size_t argc = 10;
   std::string _priority = std::to_string((uint32_t)priority);
 
-  const size_t argvlen[argc] = {
+  // Size is left for the compiler to infer from the initializer instead of
+  // a named argc constant -- some older compilers (e.g. the GCC 4.4 that
+  // shipped with CentOS 6, see #113) rejected initializing an array sized
+  // by a const size_t as though it were a VLA.
+  const size_t argvlen[]= {
     (size_t)5,
     (size_t)key.size(),
     (size_t)4,

--- a/libgearman-server/plugins/queue/redis/queue.cc
+++ b/libgearman-server/plugins/queue/redis/queue.cc
@@ -44,6 +44,7 @@
 #include <libgearman-server/plugins/queue/redis/queue.h>
 
 #include <cstdlib>
+#include <string>
 
 #if defined(GEARMAND_PLUGINS_QUEUE_REDIS_H)
 

--- a/libgearman-server/plugins/queue/redis/queue.cc
+++ b/libgearman-server/plugins/queue/redis/queue.cc
@@ -43,6 +43,8 @@
 #include <gear_config.h>
 #include <libgearman-server/plugins/queue/redis/queue.h>
 
+#include <cstdlib>
+
 #if defined(GEARMAND_PLUGINS_QUEUE_REDIS_H)
 
 /* Queue callback functions. */
@@ -252,6 +254,13 @@ bool gearmand::plugins::queue::Hiredis::fetch(char *key, gearmand::plugins::queu
     bool have_priority= false;
     for (size_t i= 0; i + 1 < reply->elements; i+= 2)
     {
+      if (reply->element[i] == nullptr or reply->element[i]->str == nullptr or
+          reply->element[i + 1] == nullptr or reply->element[i + 1]->str == nullptr)
+      {
+        gearmand_log_error(GEARMAN_DEFAULT_LOG_PARAM, "unexpected null field/value in HGETALL reply for key: %s", key);
+        return false;
+      }
+
       const char *field= reply->element[i]->str;
       const char *value= reply->element[i + 1]->str;
 
@@ -259,7 +268,13 @@ bool gearmand::plugins::queue::Hiredis::fetch(char *key, gearmand::plugins::queu
         req.data= std::string{value};
         have_data= true;
       } else if (strcmp(field, "priority") == 0) {
-        req.priority= (uint32_t)std::stoi(value);
+        char *end= nullptr;
+        unsigned long parsed_priority= std::strtoul(value, &end, 10);
+        if (end == value or *end != '\0' or parsed_priority > UINT32_MAX) {
+          gearmand_log_error(GEARMAN_DEFAULT_LOG_PARAM, "invalid priority value '%s' for key: %s", value, key);
+          return false;
+        }
+        req.priority= static_cast<uint32_t>(parsed_priority);
         have_priority= true;
       } else if (strcmp(field, "function") == 0) {
         req.function_name= std::string{value};

--- a/libgearman-server/plugins/queue/redis/queue.h
+++ b/libgearman-server/plugins/queue/redis/queue.h
@@ -59,6 +59,13 @@ namespace queue {
 struct redis_record_t {
   uint32_t priority;
   std::string data;
+  // Populated from the "function"/"unique" hash fields when present (see
+  // #159 -- older gearmand versions encoded these into the key itself,
+  // delimited by '-', which breaks for function names or unique IDs that
+  // contain a hyphen). Empty if the key predates those fields, in which
+  // case the caller must fall back to parsing the key.
+  std::string function_name;
+  std::string unique;
 };
 
 /**
@@ -107,11 +114,18 @@ class Hiredis : public Queue {
     redisContext* redis();
 
     /*
-     * hmset(vchar_t key, const void *data, size_t data_size, uint32_t)
+     * hmset(vchar_t key, const void *data, size_t data_size, uint32_t priority,
+     *       const char *function_name, size_t function_name_size,
+     *       const char *unique, size_t unique_size)
+     *
+     * function_name/unique are stored as their own hash fields (in addition
+     * to being embedded in the key) so replay can recover them without
+     * parsing the key -- see #159.
      *
      * returns true if hiredis HMSET succeeded
      */
-    bool hmset(vchar_t, const void *, size_t, uint32_t);
+    bool hmset(vchar_t, const void *, size_t, uint32_t,
+              const char *, size_t, const char *, size_t);
 
     /*
      * bool fetch(char *key, redis_record_t &req)

--- a/tests/redis.cc
+++ b/tests/redis.cc
@@ -52,7 +52,10 @@ using namespace libtest;
 #include <tests/context.h>
 
 #include "libgearman/client.hpp"
+#include "libgearman/worker.hpp"
 using namespace org::gearmand;
+
+#include "tests/workers/v2/called.h"
 
 #define WORKER_FUNCTION "hiredis_queue_test"
 
@@ -62,6 +65,7 @@ using namespace org::gearmand;
 
 static in_port_t redis_port= 0;
 static libtest::Server *redis_server_handle= NULL;
+static libtest::Server *gearmand_server_handle= NULL;
 
 static test_return_t gearmand_basic_option_test(void *)
 {
@@ -98,6 +102,8 @@ static test_return_t collection_init(void *object)
     0 };
 
   ASSERT_TRUE(test->initialize(argv));
+  gearmand_server_handle= test->_servers.last();
+  ASSERT_TRUE(gearmand_server_handle);
 
   return TEST_SUCCESS;
 }
@@ -185,6 +191,71 @@ static test_return_t redis_reconnect_after_outage(void *object)
   return TEST_SUCCESS;
 }
 
+// Regression test for #159: gearmand encoded prefix-function_name-unique
+// into the redis key and parsed it back apart on replay using '-' as the
+// delimiter, so a function name containing a hyphen got truncated at the
+// first one. Submits a job to a hyphenated function name with no worker
+// running (so it persists to redis), restarts gearmand to force a replay,
+// and confirms a worker registering the *full* function name receives it.
+static test_return_t redis_replay_hyphenated_function_name(void *object)
+{
+  Context *test= (Context *)object;
+  ASSERT_TRUE(test);
+  ASSERT_TRUE(gearmand_server_handle);
+
+  const char *function_name= "hyphenated-function-name";
+
+  {
+    libgearman::Client client(test->port());
+
+    gearman_job_handle_t job_handle= {};
+    gearman_return_t rc= gearman_client_do_background(&client, function_name, NULL,
+                                                       test_literal_param("hyphen test payload"), job_handle);
+    ASSERT_EQ(rc, GEARMAN_SUCCESS);
+    ASSERT_TRUE(job_handle[0]);
+  }
+
+  // Server::start() isn't idempotent for gearmand: calling it again on the
+  // same handle re-adds --verbose/--log-file/--pid-file on top of what's
+  // already there, and gearmand's strict option parser rejects the
+  // duplicates. Kill the old one and start a fresh Server via
+  // initialize() (same config collection_init() used) instead of trying to
+  // restart the existing handle in place.
+  ASSERT_TRUE(gearmand_server_handle->kill());
+
+  char redis_port_string[1024];
+  int length= snprintf(redis_port_string,
+                       sizeof(redis_port_string),
+                       "--redis-port=%d",
+                       int(redis_port));
+  ASSERT_TRUE(size_t(length) < sizeof(redis_port_string));
+
+  const char *argv[]= {
+    "--queue-type=redis",
+    "--redis-server=localhost",
+    redis_port_string,
+    0 };
+
+  ASSERT_TRUE(test->initialize(argv));
+  gearmand_server_handle= test->_servers.last();
+  ASSERT_TRUE(gearmand_server_handle);
+
+  libgearman::Worker worker(test->port());
+  gearman_worker_set_timeout(&worker, 3000);
+
+  Called called;
+  gearman_function_t function= gearman_function_create(called_worker);
+  ASSERT_EQ(gearman_worker_define_function(&worker,
+                                           function_name, strlen(function_name),
+                                           function,
+                                           5, &called), GEARMAN_SUCCESS);
+
+  ASSERT_EQ(gearman_worker_work(&worker), GEARMAN_SUCCESS);
+  ASSERT_TRUE(called.count());
+
+  return TEST_SUCCESS;
+}
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunreachable-code"
 static bool test_for_HAVE_HIREDIS()
@@ -234,6 +305,7 @@ test_st tests[] ={
 test_st regressions[] ={
   {"lp:734663", 0, lp_734663 },
   {"#45 reconnect after redis outage", 0, redis_reconnect_after_outage },
+  {"#159 replay hyphenated function name", 0, redis_replay_hyphenated_function_name },
   {0, 0, 0}
 };
 


### PR DESCRIPTION
## Summary

The redis key encodes `prefix-function_name-unique`, and replay parses that back apart with `sscanf("%[^-]-%[^-]-%[^*]", ...)`. Any hyphen in the function name — a completely ordinary thing to have, e.g. `foo-bar-1` — gets misparsed: the function-name field stops at the first hyphen, so `foo-bar-1` is recovered as `foo` and the rest gets folded into the unique field. Reported with a live example in #159 back in 2018; SpamapS agreed it was a legitimate bug at the time, but nothing ever landed.

Fix: store `function_name` and `unique` as their own `HMSET` fields alongside the existing `data`/`priority`, and have `_hiredis_replay()` read them directly from the hash instead of re-deriving them from the key. Falls back to the old sscanf-based key parsing only when those fields are absent, so it still handles data written by gearmand versions before this fix (or the even-older flat-string format the existing `fetch()` workaround already handles).

Also fixes #113 while in the same function: `hmset()` sized a local array off a separately-named `const size_t argc`, which GCC 4.4 (CentOS 6's system compiler) rejected as an invalid VLA initialization. Let the compiler infer the array size from the initializer instead — portable on any compiler, no behavior change.

## Test plan

- [x] Builds clean with `-Werror` (verified with a one-off nix-shell environment that adds `libmysqlclient`, since the project's default `shell.nix` doesn't build the mysql queue plugin — not relevant to this PR's files, but confirms the tree builds).
- [x] `t/redis` passes with no regressions, across multiple runs, including a new regression test (`redis_replay_hyphenated_function_name`) that submits a job to a hyphenated function name, restarts gearmand to force a replay from redis, and confirms a worker registering the full (untruncated) function name receives it.
- [x] Manual smoke test against a real redis:
  1. Submitted a background job to function `foo-bar-1` (no worker) — confirmed via `HGETALL` that the hash now has `function=foo-bar-1`/`unique=<uuid>` as separate fields.
  2. Restarted gearmand, started a worker registering `foo-bar-1` (not the truncated `foo`) — it received the replayed job.
  3. Backward-compat: hand-wrote a `data`/`priority`-only hash entry (simulating pre-fix data), restarted, confirmed it still replays correctly via the fallback key-parsing path.

Fixes #159. Fixes #113.