### PR TITLE
Fix #126: bound the mysql queue's CR_SERVER_LOST retry to one attempt

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -136,6 +136,30 @@ AC_PROG_LN_S
 AC_PROG_MAKE_SET
 AX_PROG_MEMCACHED
 AX_PROG_REDIS
+
+dnl YATL_MYSQL (libtest/m4/mysql.m4, invoked from libtest/yatl.m4) already
+dnl detects the mysqld/mariadbd server binary (HAVE_MYSQLD_BUILD/MYSQLD_BINARY)
+dnl and the mysql client library (HAVE_LIBMYSQL_BUILD). The only things it
+dnl doesn't cover, needed to spawn a throwaway instance for t/mysql, are the
+dnl install-db helper and a mysql/mariadb client binary.
+AC_PATH_PROGS([MYSQL_INSTALL_DB_BINARY],[mariadb-install-db mysql_install_db],[unknown])
+AS_IF([test x"$MYSQL_INSTALL_DB_BINARY" != xunknown -a -x "$MYSQL_INSTALL_DB_BINARY"],
+      [AC_DEFINE([HAVE_MYSQL_INSTALL_DB_BINARY], [1], [If a mysql_install_db/mariadb-install-db binary is available])
+      AC_DEFINE_UNQUOTED([MYSQL_INSTALL_DB_BINARY],"$MYSQL_INSTALL_DB_BINARY",[Path to the mysql_install_db/mariadb-install-db binary used in make test])
+      ],
+      [AC_DEFINE([HAVE_MYSQL_INSTALL_DB_BINARY], [0], [If a mysql_install_db/mariadb-install-db binary is available])
+      MYSQL_INSTALL_DB_BINARY=
+      ])
+
+AC_PATH_PROGS([MYSQL_CLIENT_BINARY],[mariadb mysql],[unknown])
+AS_IF([test x"$MYSQL_CLIENT_BINARY" != xunknown -a -x "$MYSQL_CLIENT_BINARY"],
+      [AC_DEFINE([HAVE_MYSQL_CLIENT_BINARY], [1], [If a mysql/mariadb client binary is available])
+      AC_DEFINE_UNQUOTED([MYSQL_CLIENT_BINARY],"$MYSQL_CLIENT_BINARY",[Path to the mysql/mariadb client binary used in make test])
+      ],
+      [AC_DEFINE([HAVE_MYSQL_CLIENT_BINARY], [0], [If a mysql/mariadb client binary is available])
+      MYSQL_CLIENT_BINARY=
+      ])
+
 AX_PROG_SPHINX_BUILD(,[AC_MSG_WARN([sphinx-build version 1.0 or greater is required to build man pages])])
 AX_WITH_PROG([LCOV],[lcov])
 AX_WITH_PROG([LCOV_GENHTML],[genhtml])

--- a/libgearman-server/plugins/queue/mysql/queue.cc
+++ b/libgearman-server/plugins/queue/mysql/queue.cc
@@ -331,12 +331,19 @@ static gearmand_error_t _mysql_queue_add(gearman_server_st *, void *context,
   bind[4].is_null= 0;
   bind[4].length= 0;
 
-  while(1)
+  // retried bounds this to a single reprepare-and-retry. Without it, a query
+  // that's too large for the server's max_allowed_packet gets CR_SERVER_LOST
+  // every time (MySQL closes the connection outright on an oversized packet
+  // rather than rejecting just that query), so reconnecting and retrying the
+  // *same* oversized data would otherwise loop forever (#126).
+  bool retried= false;
+  while (1)
   {
     if (mysql_stmt_bind_param(queue->add_stmt, bind))
     {
-      if ( mysql_stmt_errno(queue->add_stmt) == CR_NO_PREPARE_STMT )
+      if ( mysql_stmt_errno(queue->add_stmt) == CR_NO_PREPARE_STMT and retried == false )
       {
+        retried= true;
         if (queue->prepareAddStatement() == GEARMAND_QUEUE_ERROR)
         {
           return GEARMAND_QUEUE_ERROR;
@@ -352,8 +359,9 @@ static gearmand_error_t _mysql_queue_add(gearman_server_st *, void *context,
 
     if (mysql_stmt_execute(queue->add_stmt))
     {
-      if ( mysql_stmt_errno(queue->add_stmt) == CR_SERVER_LOST )
+      if ( mysql_stmt_errno(queue->add_stmt) == CR_SERVER_LOST and retried == false )
       {
+        retried= true;
         mysql_stmt_close(queue->add_stmt);
         if (queue->prepareAddStatement() != GEARMAND_QUEUE_ERROR)
         {
@@ -406,12 +414,17 @@ static gearmand_error_t _mysql_queue_done(gearman_server_st*, void *context,
   bind[1].is_null= 0;
   bind[1].length= (unsigned long*)&function_name_size;
 
+  // See the matching comment in _mysql_queue_add(): bound to a single
+  // reprepare-and-retry so a persistently-failing connection can't loop
+  // forever (#126).
+  bool retried= false;
   while(1)
   {
     if (mysql_stmt_bind_param(queue->done_stmt, bind))
     {
-      if ( mysql_stmt_errno(queue->done_stmt) == CR_NO_PREPARE_STMT )
+      if ( mysql_stmt_errno(queue->done_stmt) == CR_NO_PREPARE_STMT and retried == false )
       {
+        retried= true;
         if (queue->prepareDoneStatement() == GEARMAND_QUEUE_ERROR)
         {
           return GEARMAND_QUEUE_ERROR;
@@ -427,8 +440,9 @@ static gearmand_error_t _mysql_queue_done(gearman_server_st*, void *context,
 
     if (mysql_stmt_execute(queue->done_stmt))
     {
-      if ( mysql_stmt_errno(queue->done_stmt) == CR_SERVER_LOST )
+      if ( mysql_stmt_errno(queue->done_stmt) == CR_SERVER_LOST and retried == false )
       {
+        retried= true;
         mysql_stmt_close(queue->done_stmt);
         if (queue->prepareDoneStatement() != GEARMAND_QUEUE_ERROR)
         {

--- a/libtest/has.cc
+++ b/libtest/has.cc
@@ -140,6 +140,50 @@ bool has_mysqld()
   return false;
 }
 
+const char* mysqld_binary()
+{
+#if defined(MYSQLD_BINARY)
+  return MYSQLD_BINARY;
+#else
+  return NULL;
+#endif
+}
+
+bool has_mysql_install_db()
+{
+#if defined(HAVE_MYSQL_INSTALL_DB_BINARY) && HAVE_MYSQL_INSTALL_DB_BINARY
+  if (HAVE_MYSQL_INSTALL_DB_BINARY)
+  {
+#if defined(MYSQL_INSTALL_DB_BINARY)
+    if (access(MYSQL_INSTALL_DB_BINARY, X_OK) == 0)
+    {
+      return true;
+    }
+#endif
+  }
+#endif
+
+  return false;
+}
+
+const char* mysql_install_db_binary()
+{
+#if defined(MYSQL_INSTALL_DB_BINARY)
+  return MYSQL_INSTALL_DB_BINARY;
+#else
+  return NULL;
+#endif
+}
+
+const char* mysql_client_binary()
+{
+#if defined(MYSQL_CLIENT_BINARY)
+  return MYSQL_CLIENT_BINARY;
+#else
+  return NULL;
+#endif
+}
+
 static char memcached_binary_path[FILENAME_MAX +1]= { 0 };
 
 static void initialize_memcached_binary_path()

--- a/libtest/has.hpp
+++ b/libtest/has.hpp
@@ -79,4 +79,16 @@ bool has_redis();
 
 LIBTEST_API
 const char* redis_server_binary();
+
+LIBTEST_API
+bool has_mysql_install_db();
+
+LIBTEST_API
+const char* mysqld_binary();
+
+LIBTEST_API
+const char* mysql_install_db_binary();
+
+LIBTEST_API
+const char* mysql_client_binary();
 } // namespace libtest

--- a/libtest/include.am
+++ b/libtest/include.am
@@ -121,6 +121,7 @@ noinst_HEADERS+= libtest/killpid.h
 noinst_HEADERS+= libtest/libtool.hpp
 noinst_HEADERS+= libtest/memcached.h
 noinst_HEADERS+= libtest/memcached.hpp
+noinst_HEADERS+= libtest/mysqld.h
 noinst_HEADERS+= libtest/poll_error.hpp
 noinst_HEADERS+= libtest/port.h
 noinst_HEADERS+= libtest/redis.h
@@ -218,6 +219,7 @@ EXTRA_libtest_libtest_la_DEPENDENCIES+= libtest/wait
 
 # We are either building in tree, or with
 libtest_libtest_la_SOURCES+= libtest/memcached.cc
+libtest_libtest_la_SOURCES+= libtest/mysqld.cc
 libtest_libtest_la_SOURCES+= libtest/redis.cc
 
 libtest_libtest_la_LDFLAGS+= @LIBDRIZZLE_LDFLAGS@

--- a/libtest/mysqld.cc
+++ b/libtest/mysqld.cc
@@ -1,0 +1,253 @@
+/*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
+ *
+ *  YATL (i.e. libtest) library
+ *
+ *  Copyright (C) 2026 Alexei Pastuchov
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are
+ *  met:
+ *
+ *      * Redistributions of source code must retain the above copyright
+ *  notice, this list of conditions and the following disclaimer.
+ *
+ *      * Redistributions in binary form must reproduce the above
+ *  copyright notice, this list of conditions and the following disclaimer
+ *  in the documentation and/or other materials provided with the
+ *  distribution.
+ *
+ *      * The names of its contributors may not be used to endorse or
+ *  promote products derived from this software without specific prior
+ *  written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "libtest/yatlcon.h"
+
+#include "libtest/common.h"
+
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+#include <sstream>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include <libtest/server.h>
+#include <libtest/has.hpp>
+#include <libtest/mysqld.h>
+
+#ifndef __INTEL_COMPILER
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif
+
+namespace libtest {
+
+bool mysqld_create_database(const in_port_t port, const std::string& database_name)
+{
+  if (mysql_client_binary() == NULL)
+  {
+    return false;
+  }
+
+  std::ostringstream host_arg_stream;
+  host_arg_stream << "--port=" << int(port);
+  std::string host_arg= host_arg_stream.str();
+
+  std::string query_arg= "CREATE DATABASE IF NOT EXISTS " + database_name + ";";
+
+  const char *args[]= {
+    "--protocol=tcp",
+    "--host=127.0.0.1",
+    host_arg.c_str(),
+    "--user=root",
+    "--execute", query_arg.c_str(),
+    NULL
+  };
+
+  return (exec_cmdline(mysql_client_binary(), args, false) == 0);
+}
+
+class MySQLd : public libtest::Server
+{
+private:
+  std::string _datadir;
+
+public:
+  MySQLd(const std::string& host_arg, const in_port_t port_arg) :
+    libtest::Server(host_arg, port_arg, mysqld_binary(), false)
+  {
+    set_pid_file();
+  }
+
+  bool ping()
+  {
+    if (out_of_ban_killed())
+    {
+      return false;
+    }
+
+    if (mysql_client_binary() == NULL)
+    {
+      return false;
+    }
+
+    std::ostringstream host_arg_stream;
+    host_arg_stream << "--port=" << int(port());
+    std::string host_arg= host_arg_stream.str();
+
+    const char *args[]= {
+      "--protocol=tcp",
+      "--host=127.0.0.1",
+      host_arg.c_str(),
+      "--user=root",
+      "--execute", "SELECT 1;",
+      NULL
+    };
+
+    return (exec_cmdline(mysql_client_binary(), args, false) == 0);
+  }
+
+  const char *name()
+  {
+    return "mysqld";
+  }
+
+  const char *executable()
+  {
+    return mysqld_binary();
+  }
+
+  bool is_libtool()
+  {
+    return false;
+  }
+
+  bool has_port_option() const
+  {
+    return true;
+  }
+
+  virtual void port_option(Application& app, in_port_t arg)
+  {
+    char buffer[30];
+    snprintf(buffer, sizeof(buffer), "%d", int(arg));
+    app.add_option("--port", buffer);
+  }
+
+  virtual void pid_file_option(Application& app, const std::string& arg)
+  {
+    if (arg.empty() == false)
+    {
+      app.add_option("--pid-file", arg);
+    }
+  }
+
+  bool is_valgrind() const
+  {
+    return false;
+  }
+
+  // mysqld/mariadbd resolves a relative --pid-file against its own
+  // datadir, not the caller's cwd (same reasoning as Drizzle's override
+  // of this in libtest/drizzled.cc), so use the absolute /tmp form
+  // Server::set_pid_file() offers instead of the default relative one.
+  bool broken_pid_file()
+  {
+    return true;
+  }
+
+  bool build();
+};
+
+bool MySQLd::build()
+{
+  // mysqld/mariadbd, unlike redis-server, refuses to start against a
+  // datadir that hasn't been initialized first, so give this instance its
+  // own and run mariadb-install-db/mysql_install_db once before the first
+  // start(). Absolute, under /tmp: mariadb-install-db resolves a relative
+  // --datadir against its own install prefix (basedir), not the caller's
+  // cwd, so a relative path here silently ends up somewhere under the nix
+  // store instead of the intended location.
+  std::ostringstream datadir_stream;
+  datadir_stream << "/tmp/gearmand-test-mysqld." << int(port());
+  _datadir= datadir_stream.str();
+
+  if (mkdir(_datadir.c_str(), 0755) == -1 and errno != EEXIST)
+  {
+    Error << "mkdir(" << _datadir << ") failed: " << strerror(errno);
+    return false;
+  }
+
+  if (mysql_install_db_binary())
+  {
+    // mariadb-install-db is a shell script that shells out to sed and its
+    // own sibling tools via $PATH, but Application/exec_cmdline's
+    // posix_spawn() call always passes an empty environment (by design,
+    // for reproducible test subprocesses), so it can't find them that way.
+    // Use system() for this one-off setup step instead, since it inherits
+    // the environment naturally through /bin/sh -c.
+    std::string log_path= _datadir + "/install-db.log";
+    std::string command= std::string(mysql_install_db_binary()) +
+      " --datadir=" + _datadir +
+      " --auth-root-authentication-method=normal"
+      " >" + log_path + " 2>&1";
+
+    if (system(command.c_str()) != 0)
+    {
+      std::string log_contents;
+      FILE *log_fp= fopen(log_path.c_str(), "r");
+      if (log_fp)
+      {
+        char buf[4096];
+        size_t n;
+        while ((n= fread(buf, 1, sizeof(buf), log_fp)) > 0)
+        {
+          log_contents.append(buf, n);
+        }
+        fclose(log_fp);
+      }
+      Error << "mysql_install_db/mariadb-install-db failed for datadir " << _datadir
+            << " output:" << log_contents;
+      return false;
+    }
+  }
+
+  add_option("--datadir", _datadir);
+  add_option("--tmpdir", _datadir);
+  // Avoid the system-wide default socket path (/run/mysqld/mysqld.sock),
+  // which isn't writable in a sandboxed/unprivileged environment.
+  add_option("--socket", _datadir + "/mysqld.sock");
+  add_option("--skip-grant-tables");
+  add_option("--bind-address", "127.0.0.1");
+  // Small on purpose: lets tests exercise the oversized-packet/
+  // CR_SERVER_LOST path (#126) with a payload of a few megabytes instead
+  // of needing to actually send something close to the real-world default.
+  add_option("--max_allowed_packet", "1M");
+
+  return true;
+}
+
+libtest::Server *build_mysqld(const std::string& hostname, const in_port_t try_port)
+{
+  if (has_mysqld() and has_mysql_install_db())
+  {
+    return new MySQLd(hostname, try_port);
+  }
+
+  return NULL;
+}
+
+} // namespace libtest

--- a/libtest/mysqld.h
+++ b/libtest/mysqld.h
@@ -1,8 +1,8 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
  *
- *  Data Differential YATL (i.e. libtest)  library
+ *  YATL (i.e. libtest) library
  *
- *  Copyright (C) 2012 Data Differential, http://datadifferential.com/
+ *  Copyright (C) 2026 Alexei Pastuchov
  *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions are
@@ -33,91 +33,17 @@
  *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  */
-/*
-  Common include file for libtest
-*/
 
 #pragma once
 
-#include <cassert>
-#include <cerrno>
-#include <cstdlib>
-#include <sstream>
-#include <string>
+namespace libtest {
 
-#ifdef HAVE_SYS_TYPES_H
-# include <sys/types.h>
-#endif
+libtest::Server *build_mysqld(const std::string& hostname, const in_port_t try_port);
 
-#ifdef HAVE_SYS_TIME_H
-# include <sys/time.h>
-#endif
+// Creates "database_name" on a running mysqld/mariadbd instance (via the
+// mysql/mariadb client binary). Server::start()'s own ping() loop already
+// confirmed the server is up before returning, so this is safe to call
+// right after server_startup() succeeds.
+bool mysqld_create_database(const in_port_t port, const std::string& database_name);
 
-#ifdef HAVE_SYS_WAIT_H
-# include <sys/wait.h>
-#endif
-
-#ifdef HAVE_SYS_RESOURCE_H 
-# include <sys/resource.h> 
-#endif
- 
-#ifdef HAVE_FNMATCH_H
-# include <fnmatch.h>
-#endif
-
-#ifdef HAVE_ARPA_INET_H
-# include <arpa/inet.h>
-#endif
-
-#if defined(WIN32)
-# include "win32/wrappers.h"
-# define get_socket_errno() WSAGetLastError()
-#else
-# ifdef HAVE_UNISTD_H
-#  include <unistd.h>
-# endif
-# define INVALID_SOCKET -1
-# define SOCKET_ERROR -1
-# define closesocket(a) close(a)
-# define get_socket_errno() errno
-#endif
-
-#include <libtest/test.hpp>
-
-#include <libtest/is_pid.hpp>
-
-#include <libtest/gearmand.h>
-#include <libtest/blobslap_worker.h>
-#include <libtest/memcached.h>
-#include <libtest/drizzled.h>
-#include <libtest/redis.h>
-#include <libtest/mysqld.h>
-
-#include <libtest/libtool.hpp>
-#include <libtest/killpid.h>
-#include <libtest/signal.h>
-#include <libtest/dns.hpp>
-#include <libtest/formatter.hpp>
-
-struct FreeFromVector
-{
-  template <class T>
-    void operator() ( T* ptr) const
-    {
-      if (ptr)
-      {
-        free(ptr);
-        ptr= NULL;
-      }
-    }
-};
-
-struct DeleteFromVector
-{
-  template <class T>
-    void operator() ( T* ptr) const
-    {
-      delete ptr;
-      ptr= NULL;
-    }
-};
+}

--- a/libtest/server_container.cc
+++ b/libtest/server_container.cc
@@ -255,6 +255,13 @@ libtest::Server* server_startup_st::create(const std::string& server_type, in_po
       server= build_redis("localhost", try_port);
     }
   }
+  else if (server_type.compare("mysqld") == 0)
+  {
+    if (has_mysqld())
+    {
+      server= build_mysqld("localhost", try_port);
+    }
+  }
 
   return server;
 }

--- a/tests/mysql_test.cc
+++ b/tests/mysql_test.cc
@@ -45,6 +45,7 @@ using namespace libtest;
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <string>
 #include <unistd.h>
 
 #include <libgearman/gearman.h>
@@ -52,9 +53,14 @@ using namespace libtest;
 #include <tests/basic.h>
 #include <tests/context.h>
 
+#include "libgearman/client.hpp"
+using namespace org::gearmand;
+
 #ifndef __INTEL_COMPILER
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif
+
+static in_port_t mysqld_port= 0;
 
 static test_return_t gearmand_basic_option_test(void *)
 {
@@ -72,30 +78,78 @@ static test_return_t gearmand_basic_option_test(void *)
   return TEST_SUCCESS;
 }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunreachable-code"
 static test_return_t collection_init(void *object)
 {
-  return TEST_SKIPPED; // Just skip until YaTL has MySQL startup support
+  Context *test= (Context *)object;
+  fatal_assert(test);
+
+  mysqld_port= libtest::get_free_port();
+  ASSERT_TRUE(server_startup(test->_servers, "mysqld", mysqld_port, NULL));
+
+  ASSERT_TRUE(mysqld_create_database(mysqld_port, "gearman"));
+
+  char mysql_port_string[1024];
+  int length= snprintf(mysql_port_string,
+                       sizeof(mysql_port_string),
+                       "--mysql-port=%d",
+                       int(mysqld_port));
+  ASSERT_TRUE(size_t(length) < sizeof(mysql_port_string));
 
   const char *argv[]= {
     "--queue-type=MySQL",
+    "--mysql-host=127.0.0.1",
+    mysql_port_string,
+    "--mysql-user=root",
+    "--mysql-db=gearman",
     "--mysql-table=gearman",
     0 };
-
-  Context *test= (Context *)object;
-  fatal_assert(test);
 
   ASSERT_TRUE(test->initialize(argv));
 
   return TEST_SUCCESS;
 }
-#pragma GCC diagnostic pop
 
 static test_return_t collection_cleanup(void *object)
 {
   Context *test= (Context *)object;
   test->reset();
+
+  return TEST_SUCCESS;
+}
+
+// Regression test for #126: _mysql_queue_add() retried a failed INSERT
+// against CR_SERVER_LOST unconditionally and unboundedly. MySQL closes the
+// connection outright (rather than rejecting just that one query) when a
+// query exceeds max_allowed_packet, so a job whose data was too large made
+// the add path retry the exact same oversized query forever instead of
+// failing cleanly. collection_init() starts mysqld with a small
+// max_allowed_packet (see MySQLd::build() in libtest/mysqld.cc) so a
+// multi-megabyte payload reliably triggers that path.
+static test_return_t mysql_oversized_packet_does_not_hang(void *object)
+{
+  Context *test= (Context *)object;
+  ASSERT_TRUE(test);
+
+  libgearman::Client client(test->port());
+
+  std::string big_payload(2 * 1024 * 1024, 'x');
+
+  {
+    gearman_job_handle_t job_handle= {};
+    gearman_return_t rc= gearman_client_do_background(&client, "oversized_test", NULL,
+                                                       big_payload.data(), big_payload.size(), job_handle);
+    ASSERT_EQ(rc, GEARMAN_QUEUE_ERROR);
+  }
+
+  // Confirm the connection (and mysqld) is still healthy afterward -- a
+  // normal-sized job should still persist and succeed.
+  {
+    gearman_job_handle_t job_handle= {};
+    gearman_return_t rc= gearman_client_do_background(&client, "oversized_test", NULL,
+                                                       test_literal_param("small payload"), job_handle);
+    ASSERT_EQ(rc, GEARMAN_SUCCESS);
+    ASSERT_TRUE(job_handle[0]);
+  }
 
   return TEST_SUCCESS;
 }
@@ -132,9 +186,15 @@ test_st tests[] ={
   {0, 0, 0}
 };
 
+test_st regressions[] ={
+  {"#126 oversized packet does not hang", 0, mysql_oversized_packet_does_not_hang },
+  {0, 0, 0}
+};
+
 collection_st collection[] ={
   {"gearmand options", 0, 0, gearmand_basic_option_tests},
   {"mysql queue", collection_init, collection_cleanup, tests},
+  {"regressions", collection_init, collection_cleanup, regressions},
   {0, 0, 0, 0}
 };
 


### PR DESCRIPTION
## Summary

`_mysql_queue_add()`/`_mysql_queue_done()` retried unconditionally and unboundedly on `CR_SERVER_LOST`: reconnect, reprepare, then `continue` straight back into retrying the exact same query. That's fine for a transient connection drop, but MySQL closes the connection outright (rather than rejecting just that one query) when a query exceeds `max_allowed_packet` — so a job whose data is too large gets `CR_SERVER_LOST` on every single retry, forever. This matches the original report exactly: "gearman server did not write anything useful to the log" is exactly what you'd see looping silently between reconnect and retry, since the error-logging line is never reached.

Added a `retried` flag so each function reconnects and retries at most once; a second failure (of either `CR_NO_PREPARE_STMT` or `CR_SERVER_LOST`) now falls through to the existing log-and-return-error path instead of continuing.

## Test plan

- [x] Builds clean with `-Werror` (verified with a one-off nix-shell environment that adds `libmysqlclient`, since the project's default `shell.nix` doesn't build the mysql queue plugin).
- [x] Verified against a real mariadb server with `max_allowed_packet=1M`: submitted a 2MB background job with no worker running.
  - Before this fix: the add path retries the same oversized query against `CR_SERVER_LOST` indefinitely (traced through the code; not something safe to leave running for the PR itself).
  - With the fix: gearmand logs `mysql_stmt_execute failed: Server has gone away` once, returns `GEARMAND_QUEUE_ERROR`, and the submitting client gets a clean `GEARMAN_QUEUE_ERROR` immediately — no hang.
- [x] Confirmed the server stays healthy afterward by submitting and successfully persisting a normal-sized job right after the failed one.

Fixes #126.