### PR TITLE
Fix #207: refuse to start with --ssl on a binary built without SSL support

### DIFF
--- a/docs/source/gearmand/ssl.rst
+++ b/docs/source/gearmand/ssl.rst
@@ -47,7 +47,7 @@ Specifying Subject Alternative Names (SAN) is not needed for clients/workers sin
 
 Caveats:
 
-  1. Make sure your gearmand was configured with '--enable-ssl'. You will likely need to compile from source as packagers tend to not enable that option.
+  1. Make sure your gearmand was configured with '--enable-ssl'. You will likely need to compile from source as packagers tend to not enable that option. Passing '--ssl' to a gearmand binary that wasn't built with SSL support refuses to start rather than silently falling back to accepting unencrypted connections.
 
   2. The commands above generate server and client certificates valid for 730 days (2 years). If you want a different lifetime, adjust the '-days' parameters in the commands accordingly. The lifetimes of the server and client certificates should be less than or equal to the number of days until the CA certificate expires (3650 in the commands above).
 

--- a/libgearman-server/plugins/protocol/gear/protocol.cc
+++ b/libgearman-server/plugins/protocol/gear/protocol.cc
@@ -526,6 +526,17 @@ gearmand_error_t Gear::start(gearmand_st *gearmand)
 
     assert(gearmand->ctx_ssl());
   }
+#else
+  // --ssl is always a recognized option (registered unconditionally above),
+  // so a binary built without SSL support silently accepted it and fell
+  // back to plaintext instead of refusing to start (#207). Fail loudly
+  // instead: a user who asked for SSL and got an unencrypted listener with
+  // no indication of that is a security footgun, not a graceful fallback.
+  if (opt_ssl)
+  {
+    return gearmand_log_fatal(GEARMAN_DEFAULT_LOG_PARAM,
+                              "--ssl was requested, but this gearmand binary was not built with SSL support");
+  }
 #endif
 
   rc= gearmand_port_add(gearmand, _port.c_str(), _gear_con_add, _gear_con_remove);


### PR DESCRIPTION
## Summary

`--ssl` is registered as a command-line option unconditionally (`Gear::Gear()`'s constructor), but the code that actually sets up the SSL context (`SSL_CTX_load_verify_locations`/`SSL_CTX_use_certificate_file`/etc.) is entirely compiled out when `HAVE_SSL` isn't defined. The net effect: passing `--ssl` to a gearmand that wasn't built with SSL support was silently accepted, and gearmand fell back to accepting plaintext connections — exactly as originally reported in #207 ("starting gearmand in SSL mode when it hasn't been compiled with ssl support works without throwing issues... it accepts plain text connections just fine"). That's a security footgun, not a graceful fallback — a user who asked for encrypted transport gets none, with no indication of that.

Added the missing `#else` branch in `Gear::start()`: if `--ssl` was passed and `HAVE_SSL` isn't defined, log a fatal error and return, which propagates up and aborts startup instead of continuing.

The rest of #207 was about the SSL documentation being unhelpful, which esabol already addressed separately (`9a21ae4c` in 2018, explicitly referencing this issue, and a further modernization in `9e61bbd6` earlier this year) — added one line to the existing caveats section tying in this new behavior.

## Test plan

- [x] Built once with `--enable-ssl`: `t/ssl` still passes, no regression to the normal SSL path.
- [x] Built once *without* `--enable-ssl`: confirmed `gearmand --ssl` now logs `--ssl was requested, but this gearmand binary was not built with SSL support` and exits (was previously silently starting in plaintext mode).

Fixes #207.