### PR TITLE
Fix #503: don't abort() on recoverable SSL init failure

### DIFF
--- a/libgearman/connection.cc
+++ b/libgearman/connection.cc
@@ -670,7 +670,16 @@ gearman_return_t gearman_connection_st::enable_ssl()
 #if defined(HAVE_SSL) && HAVE_SSL
   if (universal.ssl())
   {
-    _ssl= SSL_new(universal.ctx_ssl());
+    SSL_CTX* ctx= universal.ctx_ssl();
+    if (ctx == NULL)
+    {
+      // ctx_ssl() already recorded the specific failure (bad cert path,
+      // SSL_CTX_new() failure, etc.) via gearman_universal_set_error().
+      close_socket();
+      return universal.error_code();
+    }
+
+    _ssl= SSL_new(ctx);
     if (_ssl == NULL)
     {
       close_socket();

--- a/libgearman/interface/universal.hpp
+++ b/libgearman/interface/universal.hpp
@@ -317,7 +317,7 @@ private:
   bool init_ssl();
 
 public:
-  SSL_CTX* ctx_ssl() 
+  SSL_CTX* ctx_ssl()
   {
     if (ssl())
     {
@@ -325,7 +325,11 @@ public:
       {
         if (init_ssl() == false)
         {
-          abort();
+          // init_ssl() has already recorded a specific error (bad cert
+          // path, SSL_CTX_new() failure, etc.) via gearman_universal_set_error().
+          // That is a recoverable connection error, not a programmer error,
+          // so let the caller see it instead of aborting the process.
+          return NULL;
         }
       }
       assert(_ctx_ssl);

--- a/tests/ssl.cc
+++ b/tests/ssl.cc
@@ -119,8 +119,35 @@ static test_return_t SSL_ECHO_TEST(void *)
   return TEST_SUCCESS;
 }
 
+#if defined(HAVE_SSL) && HAVE_SSL
+// Regression test for #503: gearman_universal_st::ctx_ssl() used to call
+// abort() on any recoverable SSL init failure (bad/unreadable CA, cert, or
+// key file), crashing the whole process instead of returning an error the
+// caller could handle. If that regresses, this test process itself
+// crashes with SIGABRT rather than reporting a clean FAIL.
+static test_return_t SSL_BAD_CERT_NO_ABORT_TEST(void *)
+{
+  gearman_universal_st universal;
+  gearman_set_log_fn(universal, error_logger, NULL, GEARMAN_VERBOSE_ERROR);
+  universal.ssl(true);
+  universal.ssl_ca_file("/no/such/gearman-test-ca.pem");
+  universal.ssl_certificate("/no/such/gearman-test-cert.pem");
+  universal.ssl_key("/no/such/gearman-test-key.pem");
+
+  ASSERT_TRUE(universal.ctx_ssl() == NULL);
+  ASSERT_EQ(GEARMAN_INVALID_ARGUMENT, universal.error_code());
+
+  gearman_universal_free(universal);
+
+  return TEST_SUCCESS;
+}
+#endif // defined(HAVE_SSL) && HAVE_SSL
+
 test_st SSL_TESTS[] ={
   {"SSL echo request/response round-trip over TLS", 0, SSL_ECHO_TEST },
+#if defined(HAVE_SSL) && HAVE_SSL
+  {"ctx_ssl() returns error instead of abort() on bad cert/key path (#503)", 0, SSL_BAD_CERT_NO_ABORT_TEST },
+#endif
   {0, 0, 0}
 };
 


### PR DESCRIPTION
## Summary
- `gearman_universal_st::ctx_ssl()` called `abort()` whenever `init_ssl()` returned `false` — but `init_ssl()` returns `false` for ordinary recoverable problems (unreadable CA/cert/key file, `SSL_CTX_new()`/`SSL_CTX_load_verify_locations()`/`SSL_CTX_use_certificate_file()`/`SSL_CTX_use_PrivateKey_file()` failures), and already records a specific `GEARMAN_INVALID_ARGUMENT` error via `gearman_universal_set_error()` before returning. `ctx_ssl()` discarded that and crashed the whole process instead of letting the caller see it.
- `ctx_ssl()` now returns `NULL` on failure, and `gearman_connection_st::enable_ssl()` propagates the already-recorded error code instead of passing a `NULL` `SSL_CTX*` to `SSL_new()`.
- Any SSL-enabled client or worker (e.g. `bin/gearman -S ...`) that hits a misconfigured or transiently unreadable cert/key now gets a clean connection error instead of `SIGABRT`.

Fixes #503.

## Test plan
- [x] Repro from #503 (bad `GEARMAND_CA_CERTIFICATE`/`GEARMAN_CLIENT_PEM`/`GEARMAN_CLIENT_KEY`) now fails cleanly instead of aborting/core-dumping.
- [x] Valid-cert SSL client/worker round trip still works (no regression).
- [x] Existing `t/ssl` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)