### PR TITLE
Improve detection of modern C++ standards and prioritize the usage of newer standards

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -56,14 +56,21 @@ AC_SUBST([lt_cv_dlopen_libs])
 
 # AC_REQUIRE(AC_PROG_CC)
 
-AC_DEFUN([CHECK_CXX0X],[
-          AC_LANG_PUSH([C++])
-          AX_CHECK_COMPILE_FLAG([-std=c++0x],[
-                                 CXX_STD="c++0x"])
-          AC_LANG_POP([C++])
-          ])
-CHECK_CXX0X
-
+# Select a C++ standard dialect flag:
+# Prefer -std=c++14 (what Homebrew and modern toolchains use), then
+# -std=c++11, then the legacy -std=c++0x name. Leave CXX_STD empty if
+# none are accepted (compiler default will be used).
+AC_DEFUN([CHECK_CXX_STD],[
+  AC_LANG_PUSH([C++])
+  AX_CHECK_COMPILE_FLAG([-std=c++14],
+    [CXX_STD="c++14"],
+    [AX_CHECK_COMPILE_FLAG([-std=c++11],
+      [CXX_STD="c++11"],
+      [AX_CHECK_COMPILE_FLAG([-std=c++0x],
+        [CXX_STD="c++0x"])])])
+  AC_LANG_POP([C++])
+])
+CHECK_CXX_STD
 
 AX_PLATFORM
 m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])
@@ -368,15 +375,9 @@ AC_CONFIG_FILES([Makefile
                  support/gearmand.pc
                  support/gearmand.spec])
 
-AS_IF([test "x${ax_enable_debug}" = "xyes"],
-      [AC_DEFUN([CHECK_CXX11],
-          [AC_LANG_PUSH([C++])
-          AX_CHECK_COMPILE_FLAG([-std=c++11], [CXX_STD="c++11"])
-          AC_LANG_POP([C++])
-          ])
-      CHECK_CXX11])
-
-CXXFLAGS=" $CXXFLAGS -std=$CXX_STD"
+# Apply the selected -std= flag only if one was found.
+AS_IF([test -n "$CXX_STD"],
+      [CXXFLAGS="$CXXFLAGS -std=$CXX_STD"])
 
 AC_OUTPUT
 


### PR DESCRIPTION
## Summary

I noticed that the macOS Homebrew recipe for gearmand 2.0.0 also included the following:
```
ENV.append "CXXFLAGS", "-std=c++14"
```
This led me to discover that the existing C++ standard checks in `configure.ac` were outdated and had some logic problems:

1. **C++11 was only probed when `--enable-debug` was set.**  
   Non-debug builds stayed on `-std=c++0x` (or nothing), even on compilers that fully support newer standards.

2. **`AC_DEFUN([CHECK_CXX11], …)` was defined inside an `AS_IF`.**  
   Defining macros conditionally is fragile and non-idiomatic, or so I'm told.

3. **No C++14 support.**  
   Homebrew’s gearmand formula already forces `-std=c++14`. This PR should alleviate that need.

4. **Empty `CXX_STD` still produced `-std=`.**  
   If neither flag was accepted, configure appended a bare `-std=` to `CXXFLAGS`, which was just wrong. Of course, the oldest compilers gearmand supports do support `-std=c++0x`, I believe, but still....

## Changes

- Replace `CHECK_CXX0X` and the debug-only `CHECK_CXX11` with a single `CHECK_CXX_STD` macro that always runs.
- Probe in order: `-std=c++14` → `-std=c++11` → `-std=c++0x`.
- Append `-std=$CXX_STD` to `CXXFLAGS` only when a usable flag was found.