### PR TITLE
Add --ping option to gearman client executable for server connectivity / health check (issue #315)

### DIFF
--- a/bin/arguments.cc
+++ b/bin/arguments.cc
@@ -72,6 +72,7 @@ Args::Args(int p_argc, char *p_argv[]) :
   _usage(false),
   _is_error(false),
   _use_ssl(false),
+  _ping(false),
   _arg_error(NULL),
   _priority(GEARMAN_JOB_PRIORITY_NORMAL),
   _timeout(-1),
@@ -89,6 +90,25 @@ Args::~Args()
 void Args::init(int argc)
 {
   int c;
+
+  /* Portable handling of --ping to avoid non-portable getopt_long(). */
+  for (int i= 1; i < argc; )
+  {
+    if (strcmp(argv[i], "--ping") == 0)
+    {
+      _ping= true;
+      /* Remove this argument so getopt() does not treat it as invalid. */
+      for (int j= i; j < argc - 1; j++)
+      {
+        argv[j]= argv[j + 1];
+      }
+      argv[--argc]= NULL;
+    }
+    else
+    {
+      i++;
+    }
+  }
 
   opterr= 0;
 

--- a/bin/arguments.cc
+++ b/bin/arguments.cc
@@ -91,13 +91,26 @@ void Args::init(int argc)
 {
   int c;
 
-  /* Portable handling of --ping to avoid non-portable getopt_long(). */
+  static const char short_opts[]= "bc:f:h:HILnNp:Pst:u:vwi:dS";
+
   for (int i= 1; i < argc; )
   {
+    if (strcmp(argv[i], "--") == 0)
+    {
+      break;
+    }
+    if (argv[i][0] == '-' && argv[i][1] != '\0' && argv[i][2] == '\0')
+    {
+      const char *opt= strchr(short_opts, argv[i][1]);
+      if (opt && opt[1] == ':')
+      {
+        i += 2;
+        continue;
+      }
+    }
     if (strcmp(argv[i], "--ping") == 0)
     {
       _ping= true;
-      /* Remove this argument so getopt() does not treat it as invalid. */
       for (int j= i; j < argc - 1; j++)
       {
         argv[j]= argv[j + 1];

--- a/bin/arguments.h
+++ b/bin/arguments.h
@@ -166,6 +166,11 @@ public:
     return _use_ssl;
   }
 
+  bool ping() const
+  {
+    return _ping;
+  }
+
   const char *argument(size_t arg)
   {
     return argv[arg];
@@ -187,7 +192,7 @@ public:
 
   bool is_error()
   {
-    if (_functions.empty())
+    if ((not _ping) && _functions.empty())
     {
       reset_arg_error();
       _arg_error= strdup("No Functions were provided");
@@ -226,6 +231,7 @@ private:
   bool _usage;
   bool _is_error;
   bool _use_ssl;
+  bool _ping;
   char *_arg_error;
   gearman_job_priority_t _priority;
   int _timeout;

--- a/bin/gearman.cc
+++ b/bin/gearman.cc
@@ -135,6 +135,11 @@ static void _read_workload(int fd, Bytes& workload);
  */
 static void usage(Args&, char *name);
 
+/**
+ * Connectivity check via ECHO_REQ (no worker required).
+ */
+static void _ping(Args &args);
+
 extern "C"
 {
 
@@ -228,6 +233,12 @@ int main(int argc, char *argv[])
     return EXIT_FAILURE;
   }
 
+  if (args.ping())
+  {
+    _ping(args);
+    return args.error();
+  }
+
   if (args.worker())
   {
     _worker(args);
@@ -238,6 +249,55 @@ int main(int argc, char *argv[])
   }
 
   return args.error();
+}
+
+void _ping(Args &args)
+{
+  libgearman::Client client;
+
+  if (args.timeout() >= 0)
+  {
+    gearman_client_set_timeout(&client, args.timeout());
+  }
+  else
+  {
+    /* Default timeout for when -t is omitted. */
+    gearman_client_set_timeout(&client, 2000);
+  }
+
+  if (getenv("GEARMAN_SERVER"))
+  {
+    if (gearman_failed(gearman_client_add_servers(&client, getenv("GEARMAN_SERVER"))))
+    {
+      error::message("Error occurred while parsing GEARMAN_SERVER", &client);
+      return;
+    }
+  }
+  else if (gearman_failed(gearman_client_add_server(&client, args.host(), args.port())))
+  {
+    error::message("gearman_client_add_server", &client);
+    return;
+  }
+
+  if (args.use_ssl())
+  {
+    /* Paths from GEARMAND_CA_CERTIFICATE / GEARMAN_CLIENT_PEM /
+       GEARMAN_CLIENT_KEY environment variables or compile-time defaults. */
+    gearman_client_add_options(&client, GEARMAN_CLIENT_SSL);
+  }
+
+  static const char payload[]= "ping";
+  gearman_return_t rc= gearman_client_echo(&client, payload, sizeof(payload) - 1);
+  if (gearman_failed(rc))
+  {
+    error::message("gearman_client_echo", &client);
+    return;
+  }
+
+  if (args.verbose())
+  {
+    fprintf(stdout, "ping OK\n");
+  }
 }
 
 void _client(Args &args)
@@ -785,18 +845,22 @@ static void usage(Args& args, char *name)
 
   fprintf(stream, "Client mode: %s [options] [<data>]\n", name);
   fprintf(stream, "Worker mode: %s -w [options] [<command> [<args> ...]]\n", name);
+  fprintf(stream, "  Ping mode: %s --ping [options]\n", name);
+  fprintf(stream, "\t              - Send ECHO request to server\n");
+  fprintf(stream, "\t                (connectivity check; no worker needed)\n");
 
-  fprintf(stream, "\nCommon options to both client and worker modes.\n");
-  fprintf(stream, "\t-f <function> - Function name to use for jobs (can give many)\n");
+  fprintf(stream, "\nCommon options to client, ping, and worker modes:\n");
   fprintf(stream, "\t-h <host>     - Job server host\n");
   fprintf(stream, "\t-H            - Print this help menu\n");
   fprintf(stream, "\t-v            - Print diagnostic information to stdout(%s)\n", args.verbose() ? "true" : "false");
   fprintf(stream, "\t-p <port>     - Job server port\n");
   fprintf(stream, "\t-t <timeout>  - Timeout in milliseconds\n");
+  fprintf(stream, "\t                (defaults to 2 seconds in ping mode)\n");
   fprintf(stream, "\t-i <pidfile>  - Create a pidfile for the process\n");
   fprintf(stream, "\t-S            - Enable SSL connections\n");
 
   fprintf(stream, "\nClient options:\n");
+  fprintf(stream, "\t-f <function> - Function name to use for jobs (can give many)\n");
   fprintf(stream, "\t-b            - Run jobs in the background(%s)\n", args.background() ? "true" : "false");
   fprintf(stream, "\t-I            - Run jobs as high priority\n");
   fprintf(stream, "\t-L            - Run jobs as low priority\n");
@@ -807,6 +871,7 @@ static void usage(Args& args, char *name)
   fprintf(stream, "\t-u <unique>   - Unique key to use for job\n");
 
   fprintf(stream, "\nWorker options:\n");
+  fprintf(stream, "\t-f <function> - Function name to use for jobs (can give many)\n");
   fprintf(stream, "\t-c <count>    - Number of jobs for worker to run before exiting\n");
   fprintf(stream, "\t-n            - Send data packet for each line(%s)\n", args.job_per_newline() ? "true" : "false");
   fprintf(stream, "\t-N            - Same as -n, but strip off the newline(%s)\n", args.strip_newline() ? "true" : "false");

--- a/bin/gearman.cc
+++ b/bin/gearman.cc
@@ -387,9 +387,14 @@ static bool _client_connect(Args &args, libgearman::Client& client)
 
   if (args.use_ssl())
   {
+#if defined(HAVE_SSL) && HAVE_SSL
     /* Paths from GEARMAND_CA_CERTIFICATE / GEARMAN_CLIENT_PEM /
        GEARMAN_CLIENT_KEY environment variables or compile-time defaults. */
     gearman_client_add_options(&client, GEARMAN_CLIENT_SSL);
+#else
+    error::message("SSL (-S) was requested, but this gearman executable was not built with SSL support");
+    return false;
+#endif
   }
 
   return true;

--- a/bin/gearman.cc
+++ b/bin/gearman.cc
@@ -88,6 +88,11 @@ struct worker_argument_t
 static void _client(Args &args);
 
 /**
+ * Establish connection to the server in client and ping modes.
+ */
+static bool _client_connect(Args &args, libgearman::Client& client);
+
+/**
  * Run client jobs.
  */
 static void _client_run(libgearman::Client& client, Args &args,
@@ -265,27 +270,10 @@ void _ping(Args &args)
     gearman_client_set_timeout(&client, 2000);
   }
 
-  if (getenv("GEARMAN_SERVER"))
+  if (not _client_connect(args, client))
   {
-    if (gearman_failed(gearman_client_add_servers(&client, getenv("GEARMAN_SERVER"))))
-    {
-      error::message("Error occurred while parsing GEARMAN_SERVER", &client);
-      args.set_error();
-      return;
-    }
-  }
-  else if (gearman_failed(gearman_client_add_server(&client, args.host(), args.port())))
-  {
-    error::message("gearman_client_add_server", &client);
     args.set_error();
     return;
-  }
-
-  if (args.use_ssl())
-  {
-    /* Paths from GEARMAND_CA_CERTIFICATE / GEARMAN_CLIENT_PEM /
-       GEARMAN_CLIENT_KEY environment variables or compile-time defaults. */
-    gearman_client_add_options(&client, GEARMAN_CLIENT_SSL);
   }
 
   static const char payload[]= "ping";
@@ -379,6 +367,32 @@ void _client(Args &args)
       _client_run(client, args, args.argument(x), strlen(args.argument(x)));
     }
   }
+}
+
+static bool _client_connect(Args &args, libgearman::Client& client)
+{
+  if (getenv("GEARMAN_SERVER"))
+  {
+    if (gearman_failed(gearman_client_add_servers(&client, getenv("GEARMAN_SERVER"))))
+    {
+      error::message("Error occurred while parsing GEARMAN_SERVER", &client);
+      return false;
+    }
+  }
+  else if (gearman_failed(gearman_client_add_server(&client, args.host(), args.port())))
+  {
+    error::message("gearman_client_add_server", &client);
+    return false;
+  }
+
+  if (args.use_ssl())
+  {
+    /* Paths from GEARMAND_CA_CERTIFICATE / GEARMAN_CLIENT_PEM /
+       GEARMAN_CLIENT_KEY environment variables or compile-time defaults. */
+    gearman_client_add_options(&client, GEARMAN_CLIENT_SSL);
+  }
+
+  return true;
 }
 
 void _client_run(libgearman::Client& client, Args &args,

--- a/bin/gearman.cc
+++ b/bin/gearman.cc
@@ -270,12 +270,14 @@ void _ping(Args &args)
     if (gearman_failed(gearman_client_add_servers(&client, getenv("GEARMAN_SERVER"))))
     {
       error::message("Error occurred while parsing GEARMAN_SERVER", &client);
+      args.set_error();
       return;
     }
   }
   else if (gearman_failed(gearman_client_add_server(&client, args.host(), args.port())))
   {
     error::message("gearman_client_add_server", &client);
+    args.set_error();
     return;
   }
 
@@ -291,6 +293,7 @@ void _ping(Args &args)
   if (gearman_failed(rc))
   {
     error::message("gearman_client_echo", &client);
+    args.set_error();
     return;
   }
 

--- a/bin/include.am
+++ b/bin/include.am
@@ -54,13 +54,24 @@ GEARMAN_PIDFILE = ${abs_top_builddir}/tests/var/tmp/Xugear.pid
 GEARMAND_PIDFILE = ${abs_top_builddir}/tests/var/tmp/Xugearmand.pid
 GEARMAND_PORT = 5999
 
-client-test: client-test-basic
+client-test: client-test-basic client-test-ping
 
 client-test-basic: $(GEARMAN_CLIENT_TEST)
 	@$(GEARMAN_CLIENT_TEST) -H 2>&1 > /dev/null
 	@$(GEARMAN_CLIENT_TEST) -w -f true -d -i $(GEARMAN_PIDFILE) -- false
 	@libtest/wait $(GEARMAN_PIDFILE)
 	@cat $(GEARMAN_PIDFILE) | xargs kill
+
+client-test-ping: $(GEARMAN_CLIENT_TEST)
+	@gearmand/gearmand --port=$(GEARMAND_PORT) --daemon --pid-file=$(GEARMAND_PIDFILE)
+	@$(GEARMAN_CLIENT_TEST) --ping -p $(GEARMAND_PORT)
+	@$(GEARMAN_CLIENT_TEST) --ping $(GEARMAND_PORT) -v | grep -q "ping ok"
+	@if $(GEARMAN_CLIENT_TEST) --ping -p 1 -t 500; then \
+	  echo "ping unexpectedly succeeded against closed port"; \
+	  exit 1; \
+	fi
+	@libtest/wait $(GEARMAND_PIDFILE)
+	@cat $(GEARMAND_PIDFILE) | xargs kill
 
 client-test-wc: $(GEARMAN_CLIENT_TEST)
 	@gearmand/gearmand --port=$(GEARMAND_PORT) --daemon --pid-file=$(GEARMAND_PIDFILE)

--- a/bin/include.am
+++ b/bin/include.am
@@ -65,7 +65,7 @@ client-test-basic: $(GEARMAN_CLIENT_TEST)
 client-test-ping: $(GEARMAN_CLIENT_TEST)
 	@gearmand/gearmand --port=$(GEARMAND_PORT) --daemon --pid-file=$(GEARMAND_PIDFILE)
 	@$(GEARMAN_CLIENT_TEST) --ping -p $(GEARMAND_PORT)
-	@$(GEARMAN_CLIENT_TEST) --ping $(GEARMAND_PORT) -v | grep -q "ping ok"
+	@$(GEARMAN_CLIENT_TEST) --ping -p $(GEARMAND_PORT) -v | grep -q "ping OK"
 	@if $(GEARMAN_CLIENT_TEST) --ping -p 1 -t 500; then \
 	  echo "ping unexpectedly succeeded against closed port"; \
 	  exit 1; \

--- a/docs/source/bin/gearman.rst
+++ b/docs/source/bin/gearman.rst
@@ -44,8 +44,22 @@ SYNOPSIS
 
    Same as -n, but strip off the newline
 
+.. option:: -S
+
+   Enable SSL connections. Certificate paths are taken from the
+   environment variables ``GEARMAND_CA_CERTIFICATE``, ``GEARMAN_CLIENT_PEM``,
+   and ``GEARMAN_CLIENT_KEY`` environment variables or from the libgearman
+   compile-time defaults.
+
 
 **Client options**
+
+.. option:: --ping
+
+   Send an ECHO request to the job server and exit. No worker is required.
+   Useful as a connectivity / health check. Exit status is 0 on success,
+   non-zero on failure. When ``-t`` is omitted, a 2-second timeout is used.
+   With ``-v``, it prints ``ping OK`` on success.
 
 .. option:: -b
 
@@ -93,6 +107,13 @@ DESCRIPTION
 
 
 With gearman you can run client and worker functions from the command line. 
+
+In ping mode (``--ping``), gearman only checks that a job server responds to
+an ECHO request. No function name (``-f``) and no worker are required. This is
+suitable for process supervisors and container health checks, for example::
+
+   gearman --ping -h example.com -p 4730
+   gearman --ping -h 127.0.0.1 -p 47300 -S -t 2000
 
 The environmental variable GEARMAN_SERVER can be used to specify multiple gearmand servers. Please see the c:func:'gearman_client_add_servers' for an explanation of the required syntax.
 


### PR DESCRIPTION
## Summary

Related to issue #315, this PR adds a `--ping` mode to the `gearman` client executable that performs a lightweight connectivity check against a job server using the binary protocol `ECHO_REQ` / `ECHO_RES` pair. The advantage here is that no worker is required to respond to this check, only a working gearmand job server.

This is intended for process supervisors, Docker/Kubernetes healthchecks, and similar ops use-cases where `gearadmin` is heavier than needed and may contend with the server’s admin path.

## Motivation

- No worker is required: the server handles `ECHO` itself.
- Exit status is 0 on success and non-zero on failure (scripting- and `HEALTHCHECK`-friendly).
- Incorporation into the `gearman` client executable avoids a separate executable when `gearman` already links with libgearman and supports all the needed host/port/timeout/SSL options.

## Behavior

```bash
gearman --ping [-h host] [-p port] [-t timeout_ms] [-S] [-v]
```

- Payload is the fixed string `"ping"`.
- Function (`-f`) is not required.
- Default port is the libgearman default (4730) when `-p` is omitted.
- Default timeout is 2000 ms when `-t` is omitted (healthcheck-oriented).
- SSL (`-S`) matches existing client mode; cert paths come from env or compile-time defaults.
- Verbose (`-v`) prints `ping OK` on success.
- `GEARMAN_SERVER` is honored the same way as normal client mode.

Examples:

```bash
gearman --ping -h example.com -v
gearman --ping -h 127.0.0.1 -p 47300 -S -t 2000
```
```dockerfile
HEALTHCHECK --interval=30s --timeout=3s --retries=3 \
  CMD gearman --ping -h localhost -p 4730 || exit 1
```

## Implementation Notes

- `--ping` is recognized with a portable pre-scan of argv before getopt().
This avoids getopt_long(), which is not available on all platforms gearmand
supports (also `configure.ac` only checks for `getopt.h`).
- Only `bin/gearman` is affected.
- `Args::is_error()` allows an empty function list when `--ping` is specified.

## Docs and Tests

- Documented in `docs/source/bin/gearman.rst` (feeds into `man/gearman.1`), including a short description and examples.
- Usage error output of `gearman` client executable updated for `--ping`.
- Also adds missing documentation for existing -S option to `docs/source/bin/gearman.rst`.
- Adds `client-test-ping` target in `bin/include.am` and added it to the  `client-test` target. It tests:
  - success against a live gearmand
  - verbose output contains ping ok
  - failure against a closed port