### PR TITLE
Fix #368: drop borrowed _recv_packet alias on receiving() error paths

### DIFF
--- a/libgearman/connection.cc
+++ b/libgearman/connection.cc
@@ -989,6 +989,18 @@ gearman_return_t gearman_connection_st::flush()
 #if __GNUC__ >= 7
   #pragma GCC diagnostic warning "-Wimplicit-fallthrough"
 #endif
+
+gearman_packet_st *gearman_connection_st::recv_error(gearman_return_t& ret)
+{
+  if (ret != GEARMAN_IO_WAIT)
+  {
+    recv_state= GEARMAN_CON_RECV_UNIVERSAL_NONE;
+    reset_recv_packet();
+  }
+
+  return NULL;
+}
+
 gearman_packet_st *gearman_connection_st::receiving(gearman_packet_st& packet_arg,
                                                     gearman_return_t& ret,
                                                     const bool recv_data)
@@ -1035,7 +1047,7 @@ gearman_packet_st *gearman_connection_st::receiving(gearman_packet_st& packet_ar
         {
           assert(universal.error_code());
           close_socket();
-          return NULL;
+          return recv_error(ret);
         }
       }
 
@@ -1049,10 +1061,7 @@ gearman_packet_st *gearman_connection_st::receiving(gearman_packet_st& packet_ar
       size_t recv_size= recv_socket(recv_buffer +recv_buffer_size, GEARMAN_RECV_BUFFER_SIZE -recv_buffer_size, ret);
       if (gearman_failed(ret))
       {
-        if (ret != GEARMAN_IO_WAIT) {
-          recv_state= GEARMAN_CON_RECV_UNIVERSAL_NONE;
-        }
-        return NULL;
+        return recv_error(ret);
       }
 
       recv_buffer_size+= recv_size;
@@ -1078,7 +1087,7 @@ gearman_packet_st *gearman_connection_st::receiving(gearman_packet_st& packet_ar
     {
       ret= gearman_error(universal, GEARMAN_MEMORY_ALLOCATION_FAILURE, "gearman_malloc((*packet_arg.universal), packet_arg.data_size)");
       close_socket();
-      return NULL;
+      return recv_error(ret);
     }
 
     packet_arg.options.free_data= true;
@@ -1093,7 +1102,7 @@ gearman_packet_st *gearman_connection_st::receiving(gearman_packet_st& packet_ar
                          packet_arg.data_size -recv_data_offset, ret);
       if (gearman_failed(ret))
       {
-        return NULL;
+        return recv_error(ret);
       }
     }
 

--- a/libgearman/connection.cc
+++ b/libgearman/connection.cc
@@ -986,11 +986,7 @@ gearman_return_t gearman_connection_st::flush()
   }
 }
 
-#if __GNUC__ >= 7
-  #pragma GCC diagnostic warning "-Wimplicit-fallthrough"
-#endif
-
-gearman_packet_st *gearman_connection_st::recv_error(gearman_return_t& ret)
+gearman_packet_st *gearman_connection_st::handle_recv_error(gearman_return_t& ret)
 {
   if (ret != GEARMAN_IO_WAIT)
   {
@@ -1001,6 +997,9 @@ gearman_packet_st *gearman_connection_st::recv_error(gearman_return_t& ret)
   return NULL;
 }
 
+#if __GNUC__ >= 7
+  #pragma GCC diagnostic warning "-Wimplicit-fallthrough"
+#endif
 gearman_packet_st *gearman_connection_st::receiving(gearman_packet_st& packet_arg,
                                                     gearman_return_t& ret,
                                                     const bool recv_data)
@@ -1047,7 +1046,7 @@ gearman_packet_st *gearman_connection_st::receiving(gearman_packet_st& packet_ar
         {
           assert(universal.error_code());
           close_socket();
-          return recv_error(ret);
+          return handle_recv_error(ret);
         }
       }
 
@@ -1061,7 +1060,7 @@ gearman_packet_st *gearman_connection_st::receiving(gearman_packet_st& packet_ar
       size_t recv_size= recv_socket(recv_buffer +recv_buffer_size, GEARMAN_RECV_BUFFER_SIZE -recv_buffer_size, ret);
       if (gearman_failed(ret))
       {
-        return recv_error(ret);
+        return handle_recv_error(ret);
       }
 
       recv_buffer_size+= recv_size;
@@ -1087,7 +1086,7 @@ gearman_packet_st *gearman_connection_st::receiving(gearman_packet_st& packet_ar
     {
       ret= gearman_error(universal, GEARMAN_MEMORY_ALLOCATION_FAILURE, "gearman_malloc((*packet_arg.universal), packet_arg.data_size)");
       close_socket();
-      return recv_error(ret);
+      return handle_recv_error(ret);
     }
 
     packet_arg.options.free_data= true;
@@ -1102,7 +1101,7 @@ gearman_packet_st *gearman_connection_st::receiving(gearman_packet_st& packet_ar
                          packet_arg.data_size -recv_data_offset, ret);
       if (gearman_failed(ret))
       {
-        return recv_error(ret);
+        return handle_recv_error(ret);
       }
     }
 

--- a/libgearman/connection.hpp
+++ b/libgearman/connection.hpp
@@ -230,7 +230,7 @@ private:
   // GEARMAN_IO_WAIT) reset the recv state machine and drop the borrowed
   // _recv_packet alias before returning to the caller, which may free the
   // packet it passed in. Always returns NULL.
-  gearman_packet_st *recv_error(gearman_return_t& ret);
+  gearman_packet_st *handle_recv_error(gearman_return_t& ret);
 
   gearman_packet_st *_recv_packet;
 };

--- a/libgearman/connection.hpp
+++ b/libgearman/connection.hpp
@@ -208,6 +208,9 @@ public:
     return _recv_packet;
   }
 
+  // _recv_packet is a non-owning alias of the packet_arg passed to receiving();
+  // the connection never owns it, so releasing our reference is just clearing
+  // the pointer, never gearman_packet_free().
   void reset_recv_packet()
   {
     _recv_packet= NULL;
@@ -222,6 +225,12 @@ private:
   gearman_return_t set_socket_options();
   size_t recv_socket(void *data, size_t data_size, gearman_return_t&);
   gearman_return_t connect_poll();
+
+  // Common error exit for receiving(): on a terminal failure (anything but
+  // GEARMAN_IO_WAIT) reset the recv state machine and drop the borrowed
+  // _recv_packet alias before returning to the caller, which may free the
+  // packet it passed in. Always returns NULL.
+  gearman_packet_st *recv_error(gearman_return_t& ret);
 
   gearman_packet_st *_recv_packet;
 };

--- a/tests/libgearman-1.0/worker_test.cc
+++ b/tests/libgearman-1.0/worker_test.cc
@@ -48,6 +48,12 @@ using namespace libtest;
 #include <cstring>
 #include <unistd.h>
 
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <poll.h>
+#include <pthread.h>
+#include <sys/socket.h>
+
 #include <libgearman-1.0/gearman.h>
 #include <libgearman/connection.hpp>
 #include "libgearman/command.h"
@@ -1932,6 +1938,134 @@ static test_return_t issue_301_server_job_timeout_stale_ptr_TEST(void *)
   return TEST_SUCCESS;
 }
 
+/* Regression test for GitHub issue #368.
+ *
+ * gearman_connection_st::_recv_packet is a *borrowed* alias of the packet the
+ * caller hands to receiving(); for a worker that packet is
+ * worker->job()->impl()->assigned.  When a blocking receive timed out in the
+ * middle of a packet, receiving() reset recv_state but left _recv_packet still
+ * pointing at the caller's packet.  gearman_worker_work() then did
+ * worker->job(NULL), freeing that packet, and gearman_worker_free() ->
+ * ~gearman_connection_st() -> close_socket() -> free_recv_packet() called
+ * gearman_packet_free() on the now-dangling pointer and crashed.
+ *
+ * The misbehaving server below accepts the worker, then sends a JOB_ASSIGN
+ * header that promises argument bytes which never arrive, so the client blocks
+ * in recv_socket() until its (short) timeout fires mid-packet.
+ */
+namespace {
+
+struct issue_368_server_st {
+  int listen_fd;
+  pthread_t thread;
+};
+
+extern "C" void *issue_368_stalling_server(void *arg)
+{
+  issue_368_server_st *server= static_cast<issue_368_server_st *>(arg);
+
+  int conn= accept(server->listen_fd, NULL, NULL);
+  if (conn == -1)
+  {
+    return NULL;
+  }
+
+  /* Drain whatever the client sends (GRAB_JOB, possibly options first). */
+  char buffer[256];
+  struct pollfd pfd= { conn, POLLIN, 0 };
+  while (poll(&pfd, 1, 150) > 0 and (pfd.revents & POLLIN))
+  {
+    if (::recv(conn, buffer, sizeof(buffer), 0) <= 0)
+    {
+      break;
+    }
+  }
+
+  /* A binary response header that claims 64 bytes of arguments... */
+  unsigned char header[GEARMAN_PACKET_HEADER_SIZE];
+  memcpy(header, "\0RES", 4);
+  uint32_t be_command= htonl(uint32_t(GEARMAN_COMMAND_JOB_ASSIGN));
+  memcpy(header + 4, &be_command, 4);
+  uint32_t be_size= htonl(uint32_t(64));
+  memcpy(header + 8, &be_size, 4);
+  if (::send(conn, header, sizeof(header), 0) != ssize_t(sizeof(header)))
+  { }
+  /* ...none of which are ever sent.  Hold the socket open well past the
+     client's timeout, then close. */
+  libtest::dream(2, 0);
+
+  close(conn);
+
+  return NULL;
+}
+
+} // namespace
+
+static test_return_t issue_368_recv_timeout_clears_recv_packet_TEST(void *)
+{
+  int listen_fd= socket(AF_INET, SOCK_STREAM, 0);
+  ASSERT_TRUE(listen_fd != -1);
+
+  int reuse= 1;
+  setsockopt(listen_fd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
+
+  struct sockaddr_in addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sin_family= AF_INET;
+  addr.sin_addr.s_addr= htonl(INADDR_LOOPBACK);
+  addr.sin_port= 0;
+  ASSERT_EQ(0, bind(listen_fd, reinterpret_cast<struct sockaddr *>(&addr), sizeof(addr)));
+
+  socklen_t addr_len= sizeof(addr);
+  ASSERT_EQ(0, getsockname(listen_fd, reinterpret_cast<struct sockaddr *>(&addr), &addr_len));
+  ASSERT_EQ(0, listen(listen_fd, 1));
+
+  const in_port_t port= ntohs(addr.sin_port);
+
+  issue_368_server_st server;
+  server.listen_fd= listen_fd;
+  ASSERT_EQ(0, pthread_create(&server.thread, NULL, issue_368_stalling_server, &server));
+
+  gearman_universal_st universal;
+  gearman_universal_set_timeout(universal, 400); // blocking, short
+
+  gearman_connection_st *con= gearman_connection_create(universal, "127.0.0.1", port);
+  ASSERT_TRUE(con);
+
+  gearman_packet_st grab_job;
+  ASSERT_EQ(GEARMAN_SUCCESS,
+            gearman_packet_create_args(universal, grab_job, GEARMAN_MAGIC_REQUEST,
+                                       GEARMAN_COMMAND_GRAB_JOB, NULL, NULL, 0));
+  ASSERT_EQ(GEARMAN_SUCCESS, con->send_packet(grab_job, true));
+  gearman_packet_free(&grab_job);
+
+  /* Heap-allocate the "assigned" packet so it can be freed while a buggy
+     connection still aliases it, exactly like worker->job(NULL). */
+  gearman_packet_st *assigned= new gearman_packet_st;
+
+  gearman_return_t ret= GEARMAN_SUCCESS;
+  con->receiving(*assigned, ret, true);
+  ASSERT_EQ(GEARMAN_TIMEOUT, ret);
+
+  /* The fix: the borrowed alias must be dropped on this terminal-error path. */
+  ASSERT_NULL(con->recv_packet());
+
+  /* Free the packet, then drive the historical crash site: teardown calling
+     free_recv_packet() on the (previously dangling) pointer. */
+  gearman_packet_free(assigned);
+  delete assigned;
+
+  con->close_socket();
+
+  delete con;
+  gearman_universal_free(universal);
+
+  pthread_join(server.thread, NULL);
+  close(listen_fd);
+
+  return TEST_SUCCESS;
+}
+
 /*********************** World functions **************************************/
 
 static void *world_create(server_startup_st& servers, test_return_t&)
@@ -1987,6 +2121,7 @@ test_st worker_TESTS[] ={
   {"echo_max", 0, echo_max_test },
   {"abandoned_worker", 0, abandoned_worker_test },
   {"issue#301: server job timeout stale pointer", 0, issue_301_server_job_timeout_stale_ptr_TEST },
+  {"issue#368: recv timeout clears borrowed recv_packet", 0, issue_368_recv_timeout_clears_recv_packet_TEST },
   {0, 0, 0}
 };
 


### PR DESCRIPTION
## Problem

`gearman_connection_st::_recv_packet` is a **non-owning alias** of the `gearman_packet_st` the caller passes to `receiving()` — `gearman_packet_create(universal, packet_arg)` just returns `&packet_arg`. For a worker grabbing a job, that packet is `worker->job()->impl()->assigned`.

Several terminal-error exits of `receiving()` returned without clearing that alias:

- **`recv_socket()` failure** — `recv_state` was reset to `GEARMAN_CON_RECV_UNIVERSAL_NONE` but `_recv_packet` was left pointing at `packet_arg`. This is the path hit when a blocking `gearman_wait()` returns `GEARMAN_TIMEOUT` (or another non-shutdown failure) mid-packet: `recv_socket()` returns *without* calling `close_socket()`.
- **`gearman_packet_unpack()` failure** and **`gearman_malloc()` failure** — these call `close_socket()` first, but it only clears recv state inside `if (fd != INVALID_SOCKET)`, so the alias survived when the socket was already gone.
- **`receive_data()` failure in `READ_DATA` state** — returned `NULL` without touching `recv_state` or `_recv_packet` at all.

After such a return the caller frees `packet_arg` (`gearman_worker_work()` → `worker->job(NULL)` → `delete job`). `_recv_packet` is now dangling, and the next `close_socket()` with a live fd — on reconnect, and again during `gearman_worker_free()` teardown — calls `free_recv_packet()` → `gearman_packet_free()` on freed memory and crashes. This matches the core dump in #368 ("_recv_packet is not a regular gearman_packet_st packet"), the crash site (`gearman_worker_free`), and the reporter's conditions (blocking API, large transfers spanning multiple reads, reconnect-after-error loop).

The `GEARMAN_SHUTDOWN_GRACEFUL` handling added in the #413 fix does not cover this — that was a different, narrower dangling-`_recv_packet` manifestation tied to the internal wakeup-pipe shutdown.

## Fix

Funnel every terminal-error exit of `receiving()` through a small `recv_error()` helper that, when the failure is not `GEARMAN_IO_WAIT`, resets `recv_state` and drops the `_recv_packet` alias (`reset_recv_packet()`, never `gearman_packet_free()` — the connection does not own it). The `IO_WAIT` / non-blocking resume path is unchanged. The `READ_DATA` failure path now also resets `recv_state` on a terminal error, matching the `recv_socket()` path.

Comments added at the `_recv_packet` declaration / `reset_recv_packet()` recording the non-owning-alias contract.

## Regression test

`issue#368` in `worker_test` drives the exact wire sequence with a deliberately stalling server: it accepts the worker, drains its `GRAB_JOB`, sends a `JOB_ASSIGN` header promising argument bytes that never arrive, then holds the socket open. A raw `gearman_connection_st` with a 400 ms blocking timeout hits `GEARMAN_TIMEOUT` mid-packet. The test asserts `con->recv_packet() == NULL` afterwards, then frees the heap `assigned` packet and calls `close_socket()` to exercise the historical teardown crash site.

| | fix applied | fix reverted |
|---|---|---|
| `issue#368` test | `[ ok ]` | `[ failed ]` — `Assertion 'con->recv_packet()' != NULL` |

Full `t/worker` suite: 59 `[ ok ]`, 0 failed. `t/round_robin` and `libgearman-1.0/t/cc_test` green. Clean build, no new warnings.

Closes #368

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFSMmdLVbwfQ1H8mq4fQem
